### PR TITLE
spiders: ArXiv spider

### DIFF
--- a/hepcrawl/items.py
+++ b/hepcrawl/items.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of hepcrawl.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # hepcrawl is a free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for
@@ -50,14 +50,41 @@ class HEPRecord(scrapy.Item):
         }
     """
     collaboration = scrapy.Field()
-    source = scrapy.Field()  # Source of the record (e.g. "World Scientific").
+    """A list of the record collaborations, if any.
+
+    .. code-block:: python
+
+        [
+            'Planck Collaboration'
+        ]
+    """
+
+    source = scrapy.Field()
+    """Source of the record, e.g. 'World Scientific'."""
+
     abstract = scrapy.Field()
+    """Abstract of the record, e.g. 'We study the dynamics of quantum...'."""
+
     title = scrapy.Field()
+    """Title of the record, e.g. 'Perturbative Renormalization of Neutron-Antineutron Operators'."""
+
     subtitle = scrapy.Field()
     free_keywords = scrapy.Field()
     classification_numbers = scrapy.Field()  # Like PACS numbers
+
     date_published = scrapy.Field()
+    """Date of publication in string format, e.g. '2016-01-14'."""
+
     dois = scrapy.Field()
+    """DOIs
+
+    .. code-block:: python
+
+        [
+            '10.1103/PhysRevD.93.016005'
+        ]
+    """
+
     related_article_doi = scrapy.Field()
     license = scrapy.Field()
     license_url = scrapy.Field()
@@ -75,8 +102,49 @@ class HEPRecord(scrapy.Item):
     journal_artid = scrapy.Field()
     journal_doctype = scrapy.Field()  # E.g. "Erratum", "Addendum"
     pubinfo_freetext = scrapy.Field()  # Raw journal reference string
+
     notes = scrapy.Field()
+    """Notes
+
+    .. code-block:: python
+
+        [
+            {
+                "source": "arXiv",
+                "value": "46 pages, 3 figures; v2 typos corrected, citations added"
+            }
+        ]
+    """
+
     references = scrapy.Field()
     collections = scrapy.Field()
     thesis = scrapy.Field()
     urls = scrapy.Field()
+
+    external_systems_number = scrapy.Field()
+    """External Systems Number
+
+    .. code-block:: python
+
+        [
+            {
+                "institute": "SPIRESTeX",
+                "value": "Mayrhofer:2012zy"
+            },
+            {
+                "institute": "arXiv",
+                "value": "oai:arXiv.org:1211.6742"
+            }
+        ]
+    """
+
+    arxiv_eprints = scrapy.Field()
+    """ArXiv E-print information
+
+    .. code-block:: python
+
+        {
+            "value": "1506.00647",
+            "categories": ['hep-ph', 'hep-lat', 'nucl-th']
+        }
+    """

--- a/hepcrawl/mappings.py
+++ b/hepcrawl/mappings.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of hepcrawl.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # hepcrawl is a free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for
@@ -83,4 +83,39 @@ OA_LICENSES = [
     r'^Creative Commons Attribution',
     r'^OA$',
     r'^Open Access$'
+]
+
+CONFERENCE_PAPERS = [
+    'colloquium',
+    'colloquiums',
+    'conf',
+    'conference',
+    'conferences',
+    'contrib',
+    'contributed',
+    'contribution',
+    'contributions',
+    'forum',
+    'lecture',
+    'lectures',
+    'meeting',
+    'meetings',
+    'pres',
+    'presented',
+    'proc',
+    'proceeding',
+    'proceedings',
+    'rencontre',
+    'rencontres',
+    'school',
+    'schools',
+    'seminar',
+    'seminars',
+    'symp',
+    'symposium',
+    'symposiums',
+    'talk',
+    'talks',
+    'workshop',
+    'workshops'
 ]

--- a/hepcrawl/spiders/arxiv_spider.py
+++ b/hepcrawl/spiders/arxiv_spider.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of hepcrawl.
+# Copyright (C) 2016 CERN.
+#
+# hepcrawl is a free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see LICENSE file for
+# more details.
+
+"""Spider for arXiv."""
+
+from scrapy import Request, Selector
+from scrapy.spiders import XMLFeedSpider
+from ..mappings import CONFERENCE_PAPERS
+from ..utils import get_first
+
+from ..items import HEPRecord
+from ..loaders import HEPLoader
+
+
+class ArxivSpider(XMLFeedSpider):
+
+    name = 'arXiv'
+    iterator = 'xml'
+    itertag = 'OAI-PMH:record'
+    namespaces = [
+        ("OAI-PMH", "http://www.openarchives.org/OAI/2.0/")
+    ]
+
+    def __init__(self, source_file=None, **kwargs):
+        """Construct Arxiv spider."""
+        super(ArxivSpider, self).__init__(**kwargs)
+        self.source_file = source_file
+
+    def start_requests(self):
+        yield Request(self.source_file)
+
+    def parse_node(self, response, node):
+        """Parse an arXiv XML exported file into a HEP record."""
+        node.remove_namespaces()
+
+        record = HEPLoader(item=HEPRecord(), selector=node, response=response)
+        record.add_xpath('title', '//title/text()')
+        record.add_xpath('abstract', '//abstract/text()')
+        record.add_xpath('date_published', '//created/text()')
+        record.add_xpath('dois', '//doi//text()')
+        record.add_xpath('pubinfo_freetext', '//journal-ref//text()')
+        record.add_value('source', 'arXiv')
+
+        authors, collab = self._get_authors_or_collaboration(node)
+        record.add_value('authors', authors)
+        record.add_value('collaboration', collab)
+
+        pages, notes, doctype = self._get_comments_info(node)
+        record.add_value('page_nr', pages)
+        record.add_value('notes', notes)
+        record.add_value('journal_doctype', doctype)
+
+        record.add_value('arxiv_eprints', self._get_arxiv_eprint(node))
+        record.add_value('external_systems_number', self._get_ext_systems_number(node))
+        # record.add_value('thesis', self._get_thesis(node))
+
+        license_str, license_url = self._get_license(node)
+        record.add_value('license', license_str)
+        record.add_value('license_url', license_url)
+
+        return record.load_item()
+
+    def _get_authors_or_collaboration(self, node):
+        author_selectors = node.xpath('//authors//author')
+
+        authors = []
+        collaboration = []
+        for selector in author_selectors:
+            author = Selector(text=selector.extract())
+            forenames = get_first(author.xpath('//forenames//text()').extract(), default='')
+            keyname = get_first(author.xpath('//keyname//text()').extract(), default='')
+
+            # Check if keyname is a collaboration, else append to authors
+            collab_phrases = ['consortium', 'collab', 'collaboration', 'team', 'group', 'for the']
+            collab_found = any(phrase for phrase in collab_phrases if phrase in keyname.lower())
+
+            if collab_found:
+                collaboration.append(keyname)
+            else:
+                authors.append({
+                    'surname': keyname,
+                    'given_names': forenames,
+                    "full_name": '{} {}'.format(forenames, keyname),
+                    'affiliations': ''
+                })
+        return authors, collaboration
+
+    def _get_comments_info(self, node):
+        comments = get_first(node.xpath('//comments//text()').extract())
+        notes = {
+            'source': 'arXiv',
+            'value': comments
+        }
+
+        page_nr = get_first(comments.split())
+        pages = page_nr if 'pages' in comments and page_nr.isdigit() else ''
+
+        doctype = 'arXiv'  # TODO: check out what happens here
+        if any(paper for paper in CONFERENCE_PAPERS if paper in comments):
+            doctype = 'ConferencePaper'
+        return pages, notes, doctype
+
+    def _get_arxiv_eprint(self, node):
+        category_str = get_first(node.xpath('//categories//text()').extract())
+        id = get_first(node.xpath('//id//text()').extract())
+        return {
+            'value': id,
+            'categories': category_str.split()
+        }
+
+    def _get_license(self, node):
+        license_url = get_first(node.xpath('//license//text()').extract())
+        license_str = ''
+        licenses = {  # TODO: more licenses here?
+            'creativecommons.org/licenses/by/3.0': 'CC-BY-3.0',
+            'creativecommons.org/licenses/by-nc-sa/3.0': 'CC-BY-NC-SA-3.0'
+        }
+
+        for key in licenses.keys():
+            if key in license_url:
+                license_str = licenses[key]
+                break
+        return license_str, license_url
+
+    def _get_ext_systems_number(self, node):
+        return {
+            'institute': 'arXiv',
+            'value': get_first(node.xpath('//identifier//text()').extract())
+        }

--- a/tests/responses/arxiv/sample_arxiv_record.xml
+++ b/tests/responses/arxiv/sample_arxiv_record.xml
@@ -1,0 +1,50 @@
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+    <responseDate>2016-01-14T15:53:12Z</responseDate>
+    <request verb="GetRecord" identifier="oai:arXiv.org:1601.03238" metadataPrefix="arXiv">http://export.arxiv.org/oai2</request>
+    <GetRecord>
+        <record>
+            <header>
+                <identifier>oai:arXiv.org:1601.03238</identifier>
+                <datestamp>2016-01-14</datestamp>
+                <setSpec>physics:gr-qc</setSpec>
+                <setSpec>physics:hep-th</setSpec>
+                <setSpec>physics:quant-ph</setSpec>
+            </header>
+            <metadata>
+                <arXiv xsi:schemaLocation="http://arxiv.org/OAI/arXiv/ http://arxiv.org/OAI/arXiv.xsd">
+                    <id>1601.03238</id>
+                    <created>2016-01-13</created>
+                    <authors>
+                        <author>
+                            <keyname>Planck Collaboration</keyname>
+                        </author>
+                        <author>
+                            <keyname>Wang</keyname>
+                            <forenames>Jieci</forenames>
+                        </author>
+                        <author>
+                            <keyname>Tian</keyname>
+                            <forenames>Zehua</forenames>
+                        </author>
+                        <author>
+                            <keyname>Jing</keyname>
+                            <forenames>Jiliang</forenames>
+                        </author>
+                        <author>
+                            <keyname>Fan</keyname>
+                            <forenames>Heng</forenames>
+                        </author>
+                    </authors>
+                    <title>Irreversible degradation of quantum coherence under relativistic motion</title>
+                    <categories>quant-ph gr-qc hep-th</categories>
+                    <comments>6 pages, 4 figures, conference paper</comments>
+                    <doi>10.1103/PhysRevD.93.016005</doi>
+                    <license>https://creativecommons.org/licenses/by/3.0/</license>
+                    <abstract>
+                        We study the dynamics of quantum coherence under Unruh thermal noise and seek under which condition the coherence can be frozen in a relativistic setting. We find that the quantum coherence can not be frozen for any acceleration due to the effect of Unruh thermal noise. We also find that quantum coherence is more robust than entanglement under the effect of Unruh thermal noise and therefore the coherence type quantum resources are more accessible for relativistic quantum information processing tasks. Besides, the dynamic of quantum coherence is found to be more sensitive than entanglement to the preparation of the detectors' initial state and the atom-field coupling strength, while it is less sensitive than entanglement to the acceleration of the detector.
+                    </abstract>
+                </arXiv>
+            </metadata>
+        </record>
+    </GetRecord>
+</OAI-PMH>

--- a/tests/test_arxiv.py
+++ b/tests/test_arxiv.py
@@ -1,0 +1,147 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of hepcrawl.
+# Copyright (C) 2016 CERN.
+#
+# hepcrawl is a free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see LICENSE file for
+# more details.
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+import pytest
+
+from hepcrawl.spiders import arxiv_spider
+from .responses import fake_response_from_file
+
+
+@pytest.fixture
+def results():
+    """Return results generator from the WSP spider."""
+    from scrapy.http import TextResponse
+
+    spider = arxiv_spider.ArxivSpider()
+    return spider.parse(fake_response_from_file('arxiv/sample_arxiv_record.xml', response_type=TextResponse))
+
+
+def test_abstract(results):
+    """Test extracting abstract."""
+    abstract = (
+        "We study the dynamics of quantum coherence under Unruh thermal noise and seek under which condition the "
+        "coherence can be frozen in a relativistic setting. We find that the quantum coherence can not be frozen for "
+        "any acceleration due to the effect of Unruh thermal noise. We also find that quantum coherence is more robust "
+        "than entanglement under the effect of Unruh thermal noise and therefore the coherence type quantum resources "
+        "are more accessible for relativistic quantum information processing tasks. Besides, the dynamic of quantum "
+        "coherence is found to be more sensitive than entanglement to the preparation of the detectors' initial state "
+        "and the atom-field coupling strength, while it is less sensitive than entanglement to the acceleration of the "
+        "detector."
+    )
+    for record in results:
+        assert 'abstract' in record
+        assert record['abstract'] == abstract
+
+
+def test_title(results):
+    """Test extracting title."""
+    title = "Irreversible degradation of quantum coherence under relativistic motion"
+    for record in results:
+        assert 'title' in record
+        assert record['title'] == title
+
+
+def test_date_published(results):
+    """Test extracting date_published."""
+    date_published = "2016-01-13"
+    for record in results:
+        assert 'date_published' in record
+        assert record['date_published'] == date_published
+
+
+def test_page_nr(results):
+    """Test extracting page_nr"""
+    page_nr = "6"
+    for record in results:
+        assert 'page_nr' in record
+        assert record['page_nr'] == page_nr
+
+
+def test_journal_doctype(results):
+    """Test journal type"""
+    doctype = 'ConferencePaper'
+    for record in results:
+        assert 'journal_doctype' in record
+        assert record['journal_doctype'] == doctype
+        break
+
+
+def test_notes(results):
+    notes = {
+        'source': 'arXiv',
+        'value': u'6 pages, 4 figures, conference paper'
+    }
+    for record in results:
+        assert 'notes' in record
+        rec_notes = record['notes'][0]
+        assert rec_notes['source'] == notes['source']
+        assert rec_notes['value'] == notes['value']
+
+
+def test_license(results):
+    """Test extracting license information."""
+    license = "CC-BY-3.0"
+    license_url = "https://creativecommons.org/licenses/by/3.0/"
+    for record in results:
+        assert 'license' in record
+        assert record['license'] == license
+        assert 'license_url' in record
+        assert record['license_url'] == license_url
+
+
+def test_dois(results):
+    """Test extracting dois."""
+    dois = ["10.1103/PhysRevD.93.016005"]
+    for record in results:
+        assert 'dois' in record
+        assert record['dois'] == dois
+
+
+def test_collaboration(results):
+    """Test extracting collaboration."""
+    collaboration = ["Planck Collaboration"]
+    for record in results:
+        assert 'collaboration' in record
+        assert record['collaboration'] == collaboration
+
+
+def test_authors(results):
+    """Test authors."""
+    author_full_names = ['Jieci Wang', 'Zehua Tian', 'Jiliang Jing', 'Heng Fan']
+    for record in results:
+        assert 'authors' in record
+        assert len(record['authors']) == 4
+        record_full_names = [author['full_name'] for author in record['authors']]
+        assert set(author_full_names) == set(record_full_names)  # assert that we have the same list of authors
+
+
+def test_arxiv_eprints(results):
+    eprints = {
+        'categories': [u'quant-ph', u'gr-qc', u'hep-th'],
+        'value': u'1601.03238'
+    }
+    for record in results:
+        assert 'arxiv_eprints' in record
+        rec_eprints = record['arxiv_eprints'][0]
+        assert rec_eprints['value'] == eprints['value']
+        assert set(rec_eprints['categories']) == set(eprints['categories'])
+
+
+def test_external_systems_number(results):
+    esn = {
+        'institute': 'arXiv',
+        'value': u'oai:arXiv.org:1601.03238'
+    }
+    for record in results:
+        assert 'external_systems_number' in record
+        rec_esn = record['external_systems_number'][0]
+        assert rec_esn['value'] == esn['value']
+        assert rec_esn['institute'] == esn['institute']


### PR DESCRIPTION
* Adds extraction of metadata of arXiv exports.

* Adds documentation and tests.

* Adds documentation for HepRecord item attributes.

Signed-off-by: Ilias Koutsakis <ilias.koutsakis@cern.ch>