### PR TITLE
loaders: output processor for DOI structure

### DIFF
--- a/hepcrawl/loaders.py
+++ b/hepcrawl/loaders.py
@@ -29,6 +29,7 @@ from .inputs import (
 from .outputs import (
     FreeKeywords,
     ClassificationNumbers,
+    Dois,
 )
 
 
@@ -92,6 +93,7 @@ class HEPLoader(ItemLoader):
 
     classification_numbers_out = ClassificationNumbers()
 
+    dois_out = Dois()
 
 class WSPLoader(HEPLoader):
     """Special Input/Output processors for a WSP record."""

--- a/hepcrawl/outputs.py
+++ b/hepcrawl/outputs.py
@@ -40,3 +40,19 @@ class ClassificationNumbers(object):
             {"standard": self.standard, "value": val}
             for val in values
         ]
+
+
+class Dois(object):
+
+    """Build the appropriate DOIs structure."""
+
+    def __init__(self, source="DOI"):
+        """Initialize the DOIs structure with a source."""
+        self.source = source
+
+    def __call__(self, values):
+        """Return the appropriate DOIs structure."""
+        return [
+            {"source": self.source, "value": val}
+            for val in values
+        ]


### PR DESCRIPTION
* Adds class `Dois` to outputs.py which creates structured DOIs in the JSON file.
* This is then called in `HEPLoader`. 

Signed-off-by: Henrik Vesterinen <henrik.vesterinen@cern.ch>