### PR TITLE
dateutils: improvements to date getting [WIP]

### DIFF
--- a/hepcrawl/dateutils.py
+++ b/hepcrawl/dateutils.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of hepcrawl.
+# Copyright (C) 2016 CERN.
+#
+# hepcrawl is a free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see LICENSE file for
+# more details.
+
+
+import six
+import re
+import time
+
+from datetime import date as real_date
+from datetime import datetime as real_datetime
+import dateutil.parser as dparser
+
+
+DATE_FORMATS_YEAR = ["%Y", "%y"]
+DATE_FORMATS_MONTH = [
+    "%Y-%m", "%Y %b", "%b %Y", "%Y %B", "%B %Y",
+    "%y-%m", "%y %b", "%b %y", "%y %B", "%B %y",
+]
+DATE_FORMATS_FULL = [
+    "%Y-%m-%d", "%d %m %Y", "%x", "%d %b %Y",
+    "%d %B %Y", "%d %b %y", "%d %B %y", "%Y-%m-%dT%H:%M:%SZ"  # NOTE: I added one format here.
+
+]
+
+
+def strftime(fmt, dt):
+    if not isinstance(dt, real_date):
+        dt = datetime(dt.tm_year, dt.tm_mon, dt.tm_mday, dt.tm_hour, dt.tm_min,
+                      dt.tm_sec)
+    if dt.year >= 1900:
+        return time.strftime(fmt, dt.timetuple())
+    illegal_formatting = _illegal_formatting.search(fmt)
+    if illegal_formatting:
+        raise TypeError("strftime of dates before 1900 does not handle %s" %
+                        illegal_formatting.group(0))
+
+    year = dt.year
+    # For every non-leap year century, advance by
+    # 6 years to get into the 28-year repeat cycle
+    delta = 2000 - year
+    off = 6 * (delta // 100 + delta // 400)
+    year = year + off
+
+    # Move to around the year 2000
+    year = year + ((2000 - year) // 28) * 28
+    timetuple = dt.timetuple()
+    s1 = time.strftime(fmt, (year,) + timetuple[1:])
+    sites1 = _findall(s1, str(year))
+
+    s2 = time.strftime(fmt, (year + 28,) + timetuple[1:])
+    sites2 = _findall(s2, str(year + 28))
+
+    sites = []
+    for site in sites1:
+        if site in sites2:
+            sites.append(site)
+
+    s = s1
+    syear = "%04d" % (dt.year,)
+    for site in sites:
+        s = s[:site] + syear + s[site + 4:]
+    return s
+
+
+def strptime(date_string, fmt):
+    return real_datetime(*(time.strptime(date_string, fmt)[:6]))
+
+
+def create_valid_date(date, date_format_full="%Y-%m-%d",
+                      date_format_month="%Y-%m", date_format_year="%Y"):
+    """Iterate over possible formats and return a valid date if found."""
+    valid_date = None
+    date = six.text_type(date)
+    for format in DATE_FORMATS_FULL:
+        try:
+            valid_date = strftime(date_format_full, (strptime(date, format)))
+            break
+        except ValueError:
+            pass
+    else:
+        for format in DATE_FORMATS_MONTH:
+            try:
+                if date.count('-') > 1:
+                    date = "-".join(date.split('-')[:2])
+                valid_date = strftime(date_format_month, (strptime(date, format)))
+                break
+            except ValueError:
+                pass
+        else:
+            for format in DATE_FORMATS_YEAR:
+                try:
+                    if date.count('-') > 0:
+                        date = date.split('-')[0]
+                    valid_date = strftime(date_format_year, (strptime(date, format)))
+                    break
+                except ValueError:
+                    pass
+    return valid_date
+
+
+def parse_date(raw_date):
+    """Get the date in correct format using dateutils.parser.
+    Note that if no month or day can be found in the raw date string, they
+    will be set to 1 (e.g., "Mar 1999" -> "1999-03-01"). If the string cannot
+    be parsed, return the string.
+    """
+    if not raw_date:
+        return date_published
+    if not isinstance(raw_date, str):
+        raw_date = str(raw_date)
+
+    try:
+        DEFAULT_DATE = real_datetime(1, 1, 1)
+        parsed_date = dparser.parse(raw_date, default=DEFAULT_DATE)
+        date_published = parsed_date.date().isoformat()
+    except ValueError:
+        date_published = raw_date
+
+    return date_published
+
+
+def format_date(raw_date):
+    """Get the ISO formatted year and date.
+    Calls first the format preserving date creator function, if that fails
+    calls the function that uses dateutils. Then tries to get year from the
+    resulting date.
+    """
+    date_published = create_valid_date(raw_date)
+    if not date_published:
+        date_published = parse_date(raw_date)
+    if not date_published:
+        date_published = ''
+
+    return date_published
+
+
+def format_year(raw_date):
+    """Get the year from the ISO formatted date."""
+    date_published = format_date(raw_date)
+    try:
+        year = dparser.parse(date_published).year
+    except ValueError:
+        year = 0
+
+    return year

--- a/hepcrawl/dateutils.py
+++ b/hepcrawl/dateutils.py
@@ -128,8 +128,7 @@ def parse_date(raw_date):
 def format_date(raw_date):
     """Get the ISO formatted year and date.
     Calls first the format preserving date creator function, if that fails
-    calls the function that uses dateutils. Then tries to get year from the
-    resulting date.
+    calls the function that uses dateutils.
     """
     date_published = create_valid_date(raw_date)
     if not date_published:

--- a/hepcrawl/loaders.py
+++ b/hepcrawl/loaders.py
@@ -36,6 +36,8 @@ from .outputs import (
 
 from .mappings import MATHML_ELEMENTS
 
+from .dateutils import format_date
+
 
 class HEPLoader(ItemLoader):
     """Input/Output processors for a HEP record.
@@ -82,6 +84,10 @@ class HEPLoader(ItemLoader):
     journal_volume_out = TakeFirst()
     journal_issue_out = TakeFirst()
     journal_doctype_out = TakeFirst()
+
+    date_published_in = MapCompose(
+        format_date,
+    )
     date_published_out = TakeFirst()
 
     related_article_doi_out = TakeFirst()

--- a/hepcrawl/spiders/base_spider.py
+++ b/hepcrawl/spiders/base_spider.py
@@ -13,6 +13,9 @@ from __future__ import absolute_import, print_function
 
 from urlparse import urljoin
 
+# import datetime
+# import dateutil.parser as dparser
+
 from scrapy import Request
 from scrapy.spiders import XMLFeedSpider
 

--- a/hepcrawl/spiders/base_spider.py
+++ b/hepcrawl/spiders/base_spider.py
@@ -13,9 +13,6 @@ from __future__ import absolute_import, print_function
 
 from urlparse import urljoin
 
-# import datetime
-# import dateutil.parser as dparser
-
 from scrapy import Request
 from scrapy.spiders import XMLFeedSpider
 
@@ -55,7 +52,6 @@ class BaseSpider(XMLFeedSpider):
     TODO:
     *With a test document of 1000 records only 974 returned.
      Check SSL and internal errors.
-    *More testing should be done (pdf link, urls)
 
 
     Happy crawling!
@@ -135,10 +131,7 @@ class BaseSpider(XMLFeedSpider):
         links = node.xpath(".//base_dc:link/text()").extract()
         urls_in_record = []
         for url in identifiers + relations + links:
-            if url.startswith('<'):
-                url = url[1:]
-            if url.endswith('>'):
-                url = url[:-1]
+            url = url.strip("<>")
             if not url.startswith("http://") and not url.startswith("https://"):
                 url = "http://{0}".format(url)
             if url not in urls_in_record:
@@ -168,8 +161,6 @@ class BaseSpider(XMLFeedSpider):
             title = titles[0]
             if len(titles) == 2:
                 subtitle = titles[1]
-            else:
-                title = " ".join(titles)
         return title, subtitle
 
     def parse_node(self, response, node):
@@ -189,7 +180,7 @@ class BaseSpider(XMLFeedSpider):
             request.meta["urls"] = urls_in_record
             request.meta["node"] = node
             return request
-        else:
+        elif direct_link:
             response.meta["direct_link"] = direct_link
             response.meta["urls"] = urls_in_record
             response.meta["node"] = node

--- a/hepcrawl/utils.py
+++ b/hepcrawl/utils.py
@@ -10,6 +10,8 @@
 import os
 import re
 import requests
+from operator import itemgetter
+from itertools import groupby
 
 from netrc import netrc
 from harvestingkit.ftp_utils import FtpHandler
@@ -158,3 +160,19 @@ def parse_domain(url):
 def has_numbers(text):
     """Detects if a string contains numbers"""
     return any(char.isdigit() for char in text)
+
+
+def range_as_string(data):
+    """Detects integer ranges in a list and returns a string representing them.
+    E.g. ["1981", "1982", "1985"] -> "1981-1982, 1985"
+    """
+    data = [int(i) for i in data]
+    ranges = []
+    for key, group in groupby(enumerate(data), lambda (index, item): index - item):
+        group = map(itemgetter(1), group)
+        if len(group) > 1:
+            rangestring = "{}-{}".format(str(group[0]), str(group[-1]))
+            ranges.append(rangestring)
+        else:
+            ranges.append(str(group[0]))
+    return ", ".join(ranges)

--- a/tests/responses/base/test_1_splash.htm
+++ b/tests/responses/base/test_1_splash.htm
@@ -1,0 +1,602 @@
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<!doctype html>
+<!--[if lt IE 7 ]> <html lang="en" class="no-js ie6"> <![endif]-->
+<!--[if IE 7 ]>    <html lang="en" class="no-js ie7"> <![endif]-->
+<!--[if IE 8 ]>    <html lang="en" class="no-js ie8"> <![endif]-->
+<!--[if IE 9 ]>    <html lang="en" class="no-js ie9"> <![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!--> <html lang="en" class="no-js"> <!--<![endif]-->
+<html>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0" /><title>Digital Collections: The effect of ground-state spin on fission and quasi-fission anisotropies</title>
+<meta name="dcterms.identifier" content="https://digitalcollections.anu.edu.au/display-item.jsp" />
+<meta name="dcterms.title" content="Digital Collections: The effect of ground-state spin on fission and quasi-fission anisotropies" />
+<meta name="dcterms.description" content="Digital Collections" />
+<meta name="dcterms.subject" content="ANU Digital Collections Repository" />
+<meta name="dcterms.modified" content="2015-11-30" />
+<meta name="dcterms.creator" content="Director, Information Services" />
+<meta name="dcterms.creator" content="mailto:director.iti@anu.edu.au" />
+<meta name="description" content="Digital Collections" />
+<meta name="subject" content="ANU Digital Collections Repository" />
+<meta name="keywords" content="ANU Digital Collections Repository" />
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<meta name="template" content="ANU Taglib 1.9.0" />
+<meta name="dcterms.publisher" content="The Australian National University" />
+<meta name="dcterms.publisher" content="webmaster@anu.edu.au" />
+<meta name="dcterms.rights" content="http://legaloffice.weblogs.anu.edu.au/content/copyright/" />
+<link href="//style.anu.edu.au/_anu/4/logos/anu.ico" rel="shortcut icon" type="image/x-icon" />
+<!--[if !IE]>--><link href="//style.anu.edu.au/_anu/4/min/www.min.css" rel="stylesheet" type="text/css" media="screen"/><!--<![endif]-->
+<!--[if lt IE 8]><link href="//style.anu.edu.au/_anu/4/min/www.ie7.min.css" rel="stylesheet" type="text/css" media="screen"/><![endif]-->
+<!--[if gt IE 7]><link href="//style.anu.edu.au/_anu/4/min/www.ie8.min.css" rel="stylesheet" type="text/css" media="screen"/><![endif]-->
+<link href="//style.anu.edu.au/_anu/4/style/anu-print.css" rel="stylesheet" type="text/css" media="print"/>
+<!-- jq -->
+<script src="//style.anu.edu.au/_anu/4/scripts/jquery.js" type="text/javascript"></script>
+<script type="text/javascript"> var $anujq = jQuery.noConflict(); </script>
+<script src="//style.anu.edu.au/_anu/4/scripts/jquery.hoverIntent.js" type="text/javascript"></script>
+<script src="//style.anu.edu.au/_anu/4/min/anu-common.min.js" type="text/javascript"></script>
+<!-- ejq -->
+<link href="//style.anu.edu.au/_anu/4/style/anu-syntax.css" rel="stylesheet" type="text/css" media="screen"/>
+
+
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+        <meta name="Generator" content="DSpace 4.3" />
+        <link rel="stylesheet" href="/css/anu-dspace.css" media="screen" type="text/css" />
+        
+
+        <link rel="search" type="application/opensearchdescription+xml" href="/open-search/description.xml" title="DSpace"/>
+
+
+<link rel="schema.DCTERMS" href="http://purl.org/dc/terms/" />
+<link rel="schema.DC" href="http://purl.org/dc/elements/1.1/" />
+<meta name="DC.creator" content="Butt, Rachel Deborah" />
+<meta name="DCTERMS.dateAccepted" content="2013-05-09T05:16:48Z" scheme="DCTERMS.W3CDTF" />
+<meta name="DCTERMS.created" content="2003-02" scheme="DCTERMS.W3CDTF" />
+<meta name="DC.identifier" content="http://hdl.handle.net/1885/10005" scheme="DCTERMS.URI" />
+<meta name="DCTERMS.abstract" content="In heavy-ion induced fusion-fission reactions, the angular distribution of fission fragments is sensitive to the mean square angular momentum brought in by the fusion process, and the nuclear shape and temperature at the fission saddle point. Experimental fission fragment angular  distributions are often used to infer one or more of these properties. Historically  the  analysis of these distributions has re­&#xD;&#xA;lied on the alignment of the total angular  momentum J of the compound nucleus,&#xD;&#xA;perpendicular to the projectile velocity.&#xD;&#xA;A full theoretical approach, written into a computer code for the first time, allows the effect of ground-state spin of the  projectile and target nuclei to be correctly&#xD;&#xA;treated. This approach takes into account the change in alignment of J due to the&#xD;&#xA;inclusion of this spin, an effect which is shown to be markedly stronger if the nucleus with appreciable spin also has a strong  quadrupole deformation. This change in&#xD;&#xA;alignment of J results in a much reduced fission fragment anisotropy. In extreme&#xD;&#xA;cases, the anisotropy may be below unity, and it ceases to be sufficient to characterise the fission fragment angular distribution. The calculations have been tested experimentally, by measuring fission and sur­ vival cross-sections and fission fragment angular distributions for the four reactions 31P+175,176Lu  and  28.29 Si+178Hf, where 176Lu is a strongly-deformed nucleus with an intrinsic spin of 7 units, and 178Hf has very similar deformation,  but zero spin. The reactions form the compound nuclei 206.207Rn. The total fusion excitation func­ tions are well-reproduced by calculations, but the fission fragment  anisotropies  are reproduced only when the nuclear spin and deformation are taken into account, con­ firming the theory  and supporting the recent understanding of the role of nuclear deformation in the fusion process and of compound nucleus angular  momentum in the fission process.&#xD;&#xA;Having established the effect in the well-understood fusion-fission reactions, the effect of nuclear spin is examined for the less well understood quasi-fission reaction. Experiments were performed to measure fission cross-sections and fission fragment angular distributions for the reactions  16O+235,238U, where 235U has a spin of 7/2 and 238U has a spin of zero. Both nuclei are quadrupole-deformed, and 160+238U was already known to exhibit evidence for quasi-fission. Theoretical calculations indicate that the fitted anisotropy is sensitive to the range of angles over which the angular  distribution is measured, showing that  where quasi-fission is present, the anisotropy is not sufficient to entirely characterise the fission fragment angular dis­ tribution. Comparison of the measured anisotropies with fusion-fission calculations shows clearly that the reaction is quasi-fission dominated. However, although exist­ ing quasi-fission models predict a strong effect from the spin of 235U, it is shown that the observed effect is appreciably stronger still in the experimental angular  range. This should be an important tool in evaluating future  models of the quasi-fission process." xml:lang="en_AU" />
+<meta name="DC.language" content="en_AU" xml:lang="en_AU" scheme="DCTERMS.RFC1766" />
+<meta name="DC.title" content="The effect of ground-state spin on fission and quasi-fission anisotropies" xml:lang="en_AU" />
+<meta name="DC.type" content="Thesis (PhD)" xml:lang="en_AU" />
+<meta name="DCTERMS.issued" content="2003" scheme="DCTERMS.W3CDTF" />
+
+<meta name="citation_date" content="2003" />
+<meta name="citation_keywords" content="Thesis (PhD)" />
+<meta name="citation_pdf_url" content="https://digitalcollections.anu.edu.au/bitstream/1885/10005/1/Butt_R.D._2003.pdf" />
+<meta name="citation_abstract_html_url" content="https://digitalcollections.anu.edu.au/handle/1885/10005" />
+<meta name="citation_language" content="en_AU" />
+<meta name="citation_title" content="The effect of ground-state spin on fission and quasi-fission anisotropies" />
+<meta name="citation_authors" content="Butt, Rachel Deborah" />
+
+
+        
+	<script type='text/javascript' src="/static/js/jquery/jquery-1.10.2.min.js"></script>
+	<script type='text/javascript' src='/static/js/jquery/jquery-ui-1.10.3.custom.min.js'></script>
+	<script type='text/javascript' src='/static/js/bootstrap/bootstrap.min.js'></script>
+	<script type='text/javascript' src='/static/js/holder.js'></script>
+	<script type="text/javascript" src="/utils.js"></script>
+    <script type="text/javascript" src="/static/js/choice-support.js"> </script>
+
+</head>
+
+<body>
+<script>$=$anujq</script>
+<script src="//style.anu.edu.au/_anu/4/scripts/collapse.js" type="text/javascript"></script>
+
+
+<!-- noindex -->
+<div id="skipnavholder"><a id="skipnav" href="#content">Skip navigation</a></div>
+<div id="print-hdr">
+<div class="left"><img src="//style.anu.edu.au/_anu/4/images/logos/anu_logo_print.png" alt="The Australian National University" height="40" width="115" /></div>
+<div class="right">
+<div class="bnr-line-1 bnr-2line">Digital Collections</div>
+<div class="bnr-line-2">Library</div>
+</div>
+<div class="blockline"></div>
+</div>
+<div id="explore-wrap">
+<div id="explore">
+<div id="explore-hdr" role="navigation">
+<ul>
+<li id="explore-li-1">
+<a href="http://www.anu.edu.au/about/explore.php">EXPLORE ANU <em>&raquo;</em></a>
+<div class="explore-hdr-jqshow explore-hdr-drop-div">
+<ul class="explore-hdr-drop" role="menu">
+<li class="noprint">&nbsp;</li>
+<li><a href="http://www.anu.edu.au/index.html">Home</a></li>
+<li><a href="http://students.anu.edu.au/">Students</a></li>
+<li><a href="http://www.anu.edu.au/research/">Research</a></li>
+<li><a href="http://www.anu.edu.au/education/">Education</a></li>
+<li><a href="http://about.anu.edu.au/">About ANU</a></li>
+<li class="padbottom2"><a href="http://www.anu.edu.au/staff/">Staff</a></li>
+<li>
+<a href="http://students.anu.edu.au/think/">Future students</a>
+<ul>
+<li><a href="http://students.anu.edu.au/events/">What's happening</a></li>
+<li><a href="http://students.anu.edu.au/programs/">Study options</a></li>
+<li><a href="http://programsandcourses.anu.edu.au/">Programs &amp; courses</a></li>
+<li><a href="http://students.anu.edu.au/applications/">How to apply</a></li>
+</ul>
+</li>
+<li><a href="http://innovation.anu.edu.au/">Business<span class="small"> &amp; </span>government</a></li>
+<li><a href="http://news.anu.edu.au/for-journalists/">Journalists &amp; Media</a></li>
+<li><a href="http://anulib.anu.edu.au">Library</a></li>
+<li><a href="https://alumniandfriends.anu.edu.au">Alumni</a></li>
+<li><a href="http://philanthropy.anu.edu.au/">Giving to ANU</a></li>
+<li class="padbottom2"><a href="http://hr.anu.edu.au/employment-at-anu/job-opportunities">Job Opportunities</a></li>
+<li class="noprint">&nbsp;</li>
+</ul>
+<ul role="menu" class="explore-hdr-drop-right ">
+<li class="text-right"><a href="#" onclick="fadeOutID('.explore-hdr-jqshow');return false;" style="cursor:pointer;">close <img class="absmiddle" alt="" src="//style.anu.edu.au/_anu/4/images/buttons/btn-close.gif" /></a></li>
+<li><a href="http://cass.anu.edu.au" class="h-cass"><em>ANU College of</em><br/>Arts &amp; Social Sciences</a></li>
+<li><a href="http://asiapacific.anu.edu.au/" class="h-cap"><em>ANU College of</em><br/>Asia &amp; the Pacific</a></li>
+<li><a href="http://cbe.anu.edu.au/" class="h-cbe"><em>ANU College of</em><br/>Business &amp; Economics</a></li>
+<li><a href="http://cecs.anu.edu.au/" class="h-cecs"><em>ANU College of</em><br/>Engineering &amp;<br/>Computer Science</a></li>
+<li><a href="http://law.anu.edu.au/" class="h-cl"><em>ANU College of</em><br/>Law</a></li>
+<li><a href="http://cmbe-cpms.anu.edu.au/" class="h-cmbe"><em>ANU College of</em><br/>Medicine, Biology &amp;<br/>Environment</a></li>
+<li><a href="http://cmbe-cpms.anu.edu.au/" class="h-cps"><em>ANU College of</em><br/>Physical &amp; Mathematical<br/>Sciences</a></li>
+<li><a href="http://about.anu.edu.au/governance-structure/university-structure/academic-structure/"><small>&raquo; more academic areas</small></a></li>
+</ul>
+</div>
+</li>
+<li id="explore-li-2"><a href="http://www.anu.edu.au/a-z/">A-Z INDEX <em>&raquo;</em></a>
+<ul role="menu" class="explore-hdr-drop azdrop explore-hdr-az-jqshow">
+<li class="text-right azclose padbottom"><a href="#" onclick="fadeOutID('.explore-hdr-az-jqshow');return false;" style="cursor:pointer;">close <img class="absmiddle" alt="" src="//style.anu.edu.au/_anu/4/images/buttons/btn-close.gif" /></a></li>
+<li class="boxlink az"><a href="http://www.anu.edu.au/a-z/?l=a">A</a></li>
+<li class="boxlink az"><a href="http://www.anu.edu.au/a-z/?l=b">B</a></li>
+<li class="boxlink az"><a href="http://www.anu.edu.au/a-z/?l=c">C</a></li>
+<li class="boxlink az"><a href="http://www.anu.edu.au/a-z/?l=d">D</a></li>
+<li class="boxlink az"><a href="http://www.anu.edu.au/a-z/?l=e">E</a></li>
+<li class="boxlink az"><a href="http://www.anu.edu.au/a-z/?l=f">F</a></li>
+<li class="boxlink az"><a href="http://www.anu.edu.au/a-z/?l=g">G</a></li>
+<li class="boxlink az"><a href="http://www.anu.edu.au/a-z/?l=h">H</a></li>
+<li class="boxlink az"><a href="http://www.anu.edu.au/a-z/?l=i">I</a></li>
+<li class="boxlink az"><a href="http://www.anu.edu.au/a-z/?l=j">J</a></li>
+<li class="boxlink az"><a href="http://www.anu.edu.au/a-z/?l=k">K</a></li>
+<li class="boxlink az"><a href="http://www.anu.edu.au/a-z/?l=l">L</a></li>
+<li class="boxlink az"><a href="http://www.anu.edu.au/a-z/?l=m">M</a></li>
+<li class="boxlink az"><a href="http://www.anu.edu.au/a-z/?l=n">N</a></li>
+<li class="boxlink az"><a href="http://www.anu.edu.au/a-z/?l=o">O</a></li>
+<li class="boxlink az"><a href="http://www.anu.edu.au/a-z/?l=p">P</a></li>
+<li class="boxlink az"><a href="http://www.anu.edu.au/a-z/?l=q">Q</a></li>
+<li class="boxlink az"><a href="http://www.anu.edu.au/a-z/?l=r">R</a></li>
+<li class="boxlink az"><a href="http://www.anu.edu.au/a-z/?l=s">S</a></li>
+<li class="boxlink az"><a href="http://www.anu.edu.au/a-z/?l=t">T</a></li>
+<li class="boxlink az"><a href="http://www.anu.edu.au/a-z/?l=u">U</a></li>
+<li class="boxlink az"><a href="http://www.anu.edu.au/a-z/?l=v">V</a></li>
+<li class="boxlink az"><a href="http://www.anu.edu.au/a-z/?l=w">W</a></li>
+<li class="boxlink az"><a href="http://www.anu.edu.au/a-z/?l=x">X</a></li>
+<li class="boxlink az"><a href="http://www.anu.edu.au/a-z/?l=y">Y</a></li>
+<li class="boxlink az"><a href="http://www.anu.edu.au/a-z/?l=z">Z</a></li>
+</ul>
+</li>
+<li id="srch-hdr-mini" class="srch-gw2"><a href="http://find.anu.edu.au">SEARCH</a>
+<ul class="explore-hdr-drop searchminidrop explore-hdr-searchmini-jqshow">
+<li class="text-right padbottom"><a href="#" onclick="fadeOutID('.explore-hdr-searchmini-jqshow');return false;" style="cursor:pointer;">close <img class="absmiddle" alt="" src="//style.anu.edu.au/_anu/4/images/buttons/btn-close.gif" /></a></li>
+<li class="text-right">
+<form action="//find.anu.edu.au/search" method="get" id="SearchForm1" role="search" autocomplete="off">
+label for="qt1"><span class="nodisplay">Search query</span><label>
+<input class="txt margintop" name="q" id="qt1" type="search" placeholder="Search web, staff &amp; maps" autocomplete="off">
+<div class="srch-divide"><div class="srch-divide2"></div></div><label for="search1a"><span class="nodisplay">Search</span></label><input type="submit" value="Go" name="search1a" id="search1a" class="btn-go margintop">
+<input type="hidden" name="client" value="anu_frontend" /><input type="hidden" name="proxystylesheet" value="anu_frontend" /><input type="hidden" name="site" value="default_collection" /><input type="hidden" name="btnG" value="Search" /><input type="hidden" name="filter" value="0" /></form>
+</li>
+<li class="noprint">&nbsp;</li>
+</ul>
+</li>
+</ul>
+</div>
+<div id="srch-hdr" class="srch-hdr-grad srch-gw2">
+<form action="//find.anu.edu.au/search" method="get" id="SearchForm" role="search" autocomplete="off">
+<div>
+<label for="qt"><span class="nodisplay">Search query</span></label><input class="txt globalsearch" name="q" id="qt" type="search" placeholder="Search web, staff, &amp; maps" autocomplete="off"/>
+<input type="hidden" name="client" value="anu_frontend"/>
+<input type="hidden" name="proxystylesheet" value="anu_frontend" />
+<input type="hidden" name="site" value="default_collection" />
+<input type="hidden" name="btnG" value="Search" />
+<input type="hidden" name="filter" value="0" />
+<label for="search1"><span class="nodisplay">Search button</span></label><input type="submit" value="GO" name="search1" id="search1" class="btn-tiny btn-black-grad">
+</div> 
+</form>
+</div>
+</div>
+</div>
+<div id="bnr-wrap" role="banner">
+<div id="bnr">
+<div id="bnr-left">
+<a href="http://www.anu.edu.au/" class="anu-logo-png"><img class="text-white" src="//style.anu.edu.au/_anu/4/images/logos/2x_anu_logo_small.png" onmouseover="this.src='//style.anu.edu.au/_anu/4/images/logos/2x_anu_logo_small_over.png';" onmouseout="this.src='//style.anu.edu.au/_anu/4/images/logos/2x_anu_logo_small.png'" onfocus="this.src='//style.anu.edu.au/_anu/4/images/logos/2x_anu_logo_small_over.png';" onblur="this.src='//style.anu.edu.au/_anu/4/images/logos/2x_anu_logo_small.png'" alt="The Australian National University" /></a>
+</div>
+<div id="bnr-right">
+<div class="bnr-line-1  bnr-2line">
+<h1><a href="/">Digital Collections</a></h1>
+</div>
+<div class="bnr-line-2 ">
+<a href="">Library</a>
+</div>
+</div>
+</div>
+<div id="bnr-underline"></div>
+</div>
+<!--<div id="skipnavtarget"><a id="main-content" class="skip" tabindex="32767"></a></div>-->
+<!--TABS -->
+<!-- endnoindex -->
+<div id="body-wrap" role="main">
+<div id="body">
+
+
+    
+    
+        <script type="text/javascript">
+            var _gaq = _gaq || [];
+            _gaq.push(['_setAccount', 'UA-5266663-1']);
+            _gaq.push(['_trackPageview']);
+
+            (function() {
+                var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+                ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+                var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+            })();
+        </script>
+    
+    
+
+<!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+<!--[if lt IE 9]>
+  <script src="/static/js/html5shiv.js"></script>
+  <script src="/static/js/respond.min.js"></script>
+<![endif]-->
+
+    
+    
+<a class="sr-only" href="#content">Skip navigation</a>
+<header class="navbar navbar-inverse navbar-fixed-top">    
+    
+            <div class="container">
+                
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<!-- noindex -->
+<div class="search-boxes full nopadbottom show-rsp noprint">
+<div class="search-menu">
+<a href="#" onclick="slideDownFadeOutToggle('#menu');return false;" style="cursor:pointer;"><img class="absmiddle" alt="" src="//style.anu.edu.au/_anu/4/images/buttons/btn-menu.gif" /></a> <a href="#" onclick="slideDownFadeOutToggle('#menu');return false;" style="cursor:pointer;">menu</a>
+</div>
+</div>
+<div id="menu" role="navigation">
+<div class="narrow">
+
+	
+	
+	<div class="search-box">
+		<p><label for="tequery">Search&nbsp;Digital&nbsp;Collections</label></p>
+		<form method="get" action="/simple-search" class="navbar-form navbar-right" scope="search">
+			<div class="form-group">
+				<input type="text" class="form-control search-query" placeholder="Search&nbsp;Digital&nbsp;Collections" name="query" id="tequery" size="25"/>
+				<input type="submit" value="Go" class="search-button" />
+			</div>
+			
+			
+		</form>
+	</div>
+	
+	<div class="menu-flat menu-main">
+<p>Browse</p>
+<ul id="nav-1">
+
+		<li><a href="/">Home</a></li>
+		<li><a href="/community-list">Communities<br/>&amp;&nbsp;Collections</a></li>
+		
+		      	<li><a href="/browse?type=dateissued">Issue Date</a></li>
+			
+		      	<li><a href="/browse?type=author">Author</a></li>
+			
+		      	<li><a href="/browse?type=title">Title</a></li>
+			
+		      	<li><a href="/browse?type=subject">Subject</a></li>
+			
+		      	<li><a href="/browse?type=type">Type</a></li>
+			
+	</ul>
+</div>
+
+
+	
+	
+	
+	<div class="menu-flat menu-main">
+<p>Sign on to:</p>
+<ul id="nav-2">
+
+	    <li><a href="/mydspace">My Digital Collections</a></li>
+	    <li><a href="/subscribe">Receive email<br/>updates</a></li>
+	    
+	</ul>
+</div>
+
+	
+	
+	<div class="menu-flat menu-main">
+<p>Statistics</p>
+<ul id="nav-3">
+
+	<li><a href="/statistics">Statistics</a></li>
+	</ul>
+</div>
+
+	
+	
+	<div class="menu-flat menu-main">
+<p>Submit</p>
+<ul id="nav-4">
+
+	    <li><a href="/submit">My Research</a></li>
+	    <li><a href="https://research.anu.edu.au/thesis/deposit.php">My Thesis</a></li>
+	</ul>
+</div>
+
+	
+	
+		
+	
+	<div class="menu-flat menu-main">
+<p>About</p>
+<ul id="nav-5">
+
+	    <li><a href="/contacts">Contacts</a></li>
+	    <li><a href="http://anulib.anu.edu.au/">Back to Library</a></li>
+		<li><script type="text/javascript">
+<!-- Javascript starts here
+document.write('<a href="#" onClick="var popupwin = window.open(\'/help/index.html\',\'dspacepopup\',\'height=600,width=550,resizable,scrollbars\');popupwin.focus();return false;">Help<\/a>');
+// -->
+</script><noscript><a href="/help/index.html" target="dspacepopup">Help</a></noscript></li>
+	</ul>
+</div>
+
+	
+</div>
+</div>
+<script src="//style.anu.edu.au/_anu/4/scripts/anu-menu.js" type="text/javascript"></script>
+<!-- endnoindex -->
+
+
+
+            </div>
+
+</header>
+
+<main id="content" role="main">
+                
+
+<div class="container">
+                
+
+
+
+
+  
+
+
+<div id="breadcrumb">
+
+  <a href="/">Digital Collections</a>
+
+   &raquo; <a href="/handle/1885/1">ANU Research</a>
+
+   &raquo; <a href="/handle/1885/9048">ANU Digital Theses</a>
+
+   &raquo; <a href="/handle/1885/3">Open Access Digital Theses</a>
+
+</div>
+
+</div>                
+
+
+
+        
+<div class="container">
+		
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<div class="doublewide ">
+
+
+
+		
+		
+		
+		
+
+                
+				<div class="msg-info marginbottom">
+
+                <div class="well">Please use this identifier to cite or link to this item:
+                <code>http://hdl.handle.net/1885/10005</code></div>
+				</div>
+
+
+
+
+    
+    <table class="table itemDisplayTable">
+<tr><td class="metadataFieldLabel">Title:&nbsp;</td><td class="metadataFieldValue">The&#x20;effect&#x20;of&#x20;ground-state&#x20;spin&#x20;on&#x20;fission&#x20;and&#x20;quasi-fission&#x20;anisotropies</td></tr>
+<tr><td class="metadataFieldLabel">Author(s):&nbsp;</td><td class="metadataFieldValue"><a class="author"href="/browse?type=author&amp;value=Butt%2C+Rachel+Deborah">Butt,&#x20;Rachel&#x20;Deborah</a></td></tr>
+<tr><td class="metadataFieldLabel">Affiliation:&nbsp;</td><td class="metadataFieldValue">Research&#x20;School&#x20;of&#x20;Physics&#x20;&amp;&#x20;Engineering</td></tr>
+<tr><td class="metadataFieldLabel">Date created:&nbsp;</td><td class="metadataFieldValue">2003-02</td></tr>
+<tr><td class="metadataFieldLabel">Year accepted:&nbsp;</td><td class="metadataFieldValue">2003</td></tr>
+<tr><td class="metadataFieldLabel">Description:&nbsp;</td><td class="metadataFieldValue"><div class="scroll">In&#x20;heavy-ion&#x20;induced&#x20;fusion-fission&#x20;reactions,&#x20;the&#x20;angular&#x20;distribution&#x20;of&#x20;fission&#x20;fragments&#x20;is&#x20;sensitive&#x20;to&#x20;the&#x20;mean&#x20;square&#x20;angular&#x20;momentum&#x20;brought&#x20;in&#x20;by&#x20;the&#x20;fusion&#x20;process,&#x20;and&#x20;the&#x20;nuclear&#x20;shape&#x20;and&#x20;temperature&#x20;at&#x20;the&#x20;fission&#x20;saddle&#x20;point.&#x20;Experimental&#x20;fission&#x20;fragment&#x20;angular&#x20;&#x20;distributions&#x20;are&#x20;often&#x20;used&#x20;to&#x20;infer&#x20;one&#x20;or&#x20;more&#x20;of&#x20;these&#x20;properties.&#x20;Historically&#x20;&#x20;the&#x20;&#x20;analysis&#x20;of&#x20;these&#x20;distributions&#x20;has&#x20;re­&#x0D;&#x0A;lied&#x20;on&#x20;the&#x20;alignment&#x20;of&#x20;the&#x20;total&#x20;angular&#x20;&#x20;momentum&#x20;J&#x20;of&#x20;the&#x20;compound&#x20;nucleus,&#x0D;&#x0A;perpendicular&#x20;to&#x20;the&#x20;projectile&#x20;velocity.&#x0D;&#x0A;A&#x20;full&#x20;theoretical&#x20;approach,&#x20;written&#x20;into&#x20;a&#x20;computer&#x20;code&#x20;for&#x20;the&#x20;first&#x20;time,&#x20;allows&#x20;the&#x20;effect&#x20;of&#x20;ground-state&#x20;spin&#x20;of&#x20;the&#x20;&#x20;projectile&#x20;and&#x20;target&#x20;nuclei&#x20;to&#x20;be&#x20;correctly&#x0D;&#x0A;treated.&#x20;This&#x20;approach&#x20;takes&#x20;into&#x20;account&#x20;the&#x20;change&#x20;in&#x20;alignment&#x20;of&#x20;J&#x20;due&#x20;to&#x20;the&#x0D;&#x0A;inclusion&#x20;of&#x20;this&#x20;spin,&#x20;an&#x20;effect&#x20;which&#x20;is&#x20;shown&#x20;to&#x20;be&#x20;markedly&#x20;stronger&#x20;if&#x20;the&#x20;nucleus&#x20;with&#x20;appreciable&#x20;spin&#x20;also&#x20;has&#x20;a&#x20;strong&#x20;&#x20;quadrupole&#x20;deformation.&#x20;This&#x20;change&#x20;in&#x0D;&#x0A;alignment&#x20;of&#x20;J&#x20;results&#x20;in&#x20;a&#x20;much&#x20;reduced&#x20;fission&#x20;fragment&#x20;anisotropy.&#x20;In&#x20;extreme&#x0D;&#x0A;cases,&#x20;the&#x20;anisotropy&#x20;may&#x20;be&#x20;below&#x20;unity,&#x20;and&#x20;it&#x20;ceases&#x20;to&#x20;be&#x20;sufficient&#x20;to&#x20;characterise&#x20;the&#x20;fission&#x20;fragment&#x20;angular&#x20;distribution.&#x20;The&#x20;calculations&#x20;have&#x20;been&#x20;tested&#x20;experimentally,&#x20;by&#x20;measuring&#x20;fission&#x20;and&#x20;sur­&#x20;vival&#x20;cross-sections&#x20;and&#x20;fission&#x20;fragment&#x20;angular&#x20;distributions&#x20;for&#x20;the&#x20;four&#x20;reactions&#x20;31P+175,176Lu&#x20;&#x20;and&#x20;&#x20;28.29&#x20;Si+178Hf,&#x20;where&#x20;176Lu&#x20;is&#x20;a&#x20;strongly-deformed&#x20;nucleus&#x20;with&#x20;an&#x20;intrinsic&#x20;spin&#x20;of&#x20;7&#x20;units,&#x20;and&#x20;178Hf&#x20;has&#x20;very&#x20;similar&#x20;deformation,&#x20;&#x20;but&#x20;zero&#x20;spin.&#x20;The&#x20;reactions&#x20;form&#x20;the&#x20;compound&#x20;nuclei&#x20;206.207Rn.&#x20;The&#x20;total&#x20;fusion&#x20;excitation&#x20;func­&#x20;tions&#x20;are&#x20;well-reproduced&#x20;by&#x20;calculations,&#x20;but&#x20;the&#x20;fission&#x20;fragment&#x20;&#x20;anisotropies&#x20;&#x20;are&#x20;reproduced&#x20;only&#x20;when&#x20;the&#x20;nuclear&#x20;spin&#x20;and&#x20;deformation&#x20;are&#x20;taken&#x20;into&#x20;account,&#x20;con­&#x20;firming&#x20;the&#x20;theory&#x20;&#x20;and&#x20;supporting&#x20;the&#x20;recent&#x20;understanding&#x20;of&#x20;the&#x20;role&#x20;of&#x20;nuclear&#x20;deformation&#x20;in&#x20;the&#x20;fusion&#x20;process&#x20;and&#x20;of&#x20;compound&#x20;nucleus&#x20;angular&#x20;&#x20;momentum&#x20;in&#x20;the&#x20;fission&#x20;process.&#x0D;&#x0A;Having&#x20;established&#x20;the&#x20;effect&#x20;in&#x20;the&#x20;well-understood&#x20;fusion-fission&#x20;reactions,&#x20;the&#x20;effect&#x20;of&#x20;nuclear&#x20;spin&#x20;is&#x20;examined&#x20;for&#x20;the&#x20;less&#x20;well&#x20;understood&#x20;quasi-fission&#x20;reaction.&#x20;Experiments&#x20;were&#x20;performed&#x20;to&#x20;measure&#x20;fission&#x20;cross-sections&#x20;and&#x20;fission&#x20;fragment&#x20;angular&#x20;distributions&#x20;for&#x20;the&#x20;reactions&#x20;&#x20;16O+235,238U,&#x20;where&#x20;235U&#x20;has&#x20;a&#x20;spin&#x20;of&#x20;7&#x2F;2&#x20;and&#x20;238U&#x20;has&#x20;a&#x20;spin&#x20;of&#x20;zero.&#x20;Both&#x20;nuclei&#x20;are&#x20;quadrupole-deformed,&#x20;and&#x20;160+238U&#x20;was&#x20;already&#x20;known&#x20;to&#x20;exhibit&#x20;evidence&#x20;for&#x20;quasi-fission.&#x20;Theoretical&#x20;calculations&#x20;indicate&#x20;that&#x20;the&#x20;fitted&#x20;anisotropy&#x20;is&#x20;sensitive&#x20;to&#x20;the&#x20;range&#x20;of&#x20;angles&#x20;over&#x20;which&#x20;the&#x20;angular&#x20;&#x20;distribution&#x20;is&#x20;measured,&#x20;showing&#x20;that&#x20;&#x20;where&#x20;quasi-fission&#x20;is&#x20;present,&#x20;the&#x20;anisotropy&#x20;is&#x20;not&#x20;sufficient&#x20;to&#x20;entirely&#x20;characterise&#x20;the&#x20;fission&#x20;fragment&#x20;angular&#x20;dis­&#x20;tribution.&#x20;Comparison&#x20;of&#x20;the&#x20;measured&#x20;anisotropies&#x20;with&#x20;fusion-fission&#x20;calculations&#x20;shows&#x20;clearly&#x20;that&#x20;the&#x20;reaction&#x20;is&#x20;quasi-fission&#x20;dominated.&#x20;However,&#x20;although&#x20;exist­&#x20;ing&#x20;quasi-fission&#x20;models&#x20;predict&#x20;a&#x20;strong&#x20;effect&#x20;from&#x20;the&#x20;spin&#x20;of&#x20;235U,&#x20;it&#x20;is&#x20;shown&#x20;that&#x20;the&#x20;observed&#x20;effect&#x20;is&#x20;appreciably&#x20;stronger&#x20;still&#x20;in&#x20;the&#x20;experimental&#x20;angular&#x20;&#x20;range.&#x20;This&#x20;should&#x20;be&#x20;an&#x20;important&#x20;tool&#x20;in&#x20;evaluating&#x20;future&#x20;&#x20;models&#x20;of&#x20;the&#x20;quasi-fission&#x20;process.</div></td></tr>
+<tr><td class="metadataFieldLabel">URI:&nbsp;</td><td class="metadataFieldValue"><a href="http://hdl.handle.net/1885/10005">http:&#x2F;&#x2F;hdl.handle.net&#x2F;1885&#x2F;10005</a></td></tr>
+<tr><td class="metadataFieldLabel">Appears in Collections:</td><td class="metadataFieldValue"><a href="/handle/1885/3">Open Access Digital Theses</a><br/></td></tr>
+</table><br/>
+<div class="panel panel-info"><div class="panel-heading">Files in This Item:</div>
+<table class="table panel-body"><tr><th id="t1" class="standard">File</th>
+<th id="t2" class="standard">Description</th>
+<th id="t3" class="standard">Size</th><th id="t4" class="standard">Format</th><th>&nbsp;</th></tr>
+<tr><td headers="t1" class="standard"><a target="_blank" href="/bitstream/1885/10005/1/Butt_R.D._2003.pdf">Butt_R.D._2003.pdf</a></td><td headers="t2" class="standard"></td><td headers="t3" class="standard">21.27 MB</td><td headers="t4" class="standard">Adobe PDF</td><td class="standard" align="center"><a target="_blank" href="/bitstream/1885/10005/1/Butt_R.D._2003.pdf"><img src="/retrieve/47554/Butt_R.D._2003.pdf.jpg" alt="Thumbnail" /></a><br /><a class="btn btn-primary" target="_blank" href="/bitstream/1885/10005/1/Butt_R.D._2003.pdf">View/Open</a></td></tr></table>
+</div>
+
+<div class="container row">
+
+
+    <a class="btn btn-default" href="/handle/1885/10005?mode=full">
+        Show full item record
+    </a>
+
+    <a class="statisticsLink  btn btn-primary" href="/handle/1885/10005/statistics" rel="nofollow"><span class="glyphicon glyphicon-stats">Statistics</span></a>
+	<a class="btn btn-primary" href="/exportreference?handle=1885/10005&format=bibtex" rel="nofollow">Export BibTeX</a>
+	<a class="btn btn-primary" href="/exportreference?handle=1885/10005&format=endnote" rel="nofollow">Export EndNote</a>
+	
+	<!-- Altmetric badge Start -->
+
+	<!-- Altmetric badge End -->
+	
+    
+
+</div>
+<br/>
+    
+
+<br/>
+    
+
+    <p class="submitFormHelp alert alert-info">Items in Digital Collections are protected by copyright, with all rights reserved, unless otherwise indicated.</p>
+    
+
+
+
+
+
+
+
+
+
+
+
+
+
+            
+
+</div>
+</main>
+            
+            <!-- 
+             <footer class="navbar navbar-inverse navbar-bottom">
+             <div id="designedby" class="container text-muted">
+             Theme by <a href="http://www.cineca.it"><img
+                                    src="/image/logo-cineca-small.png"
+                                    alt="Logo CINECA" /></a>
+			<div id="footer_feedback" class="pull-right">                                    
+                                <p class="text-muted"><a target="_blank" href="http://www.digitalcollectinos.anu.edu.au/">Digital Collections Software</a> Copyright&nbsp;&copy;&nbsp;2002-2010&nbsp; <a target="_blank" href="http://www.duraspace.org/">Duraspace</a>&nbsp;-
+                                <a target="_blank" href="/feedback">Feedback</a>
+                                <a href="/htmlmap"></a></p>
+                                </div>
+			</div>
+    </footer>
+     -->
+     
+    <!-- noindex -->
+<div id="update-wrap">
+<div id="update-details">
+<p class="sml-hdr">
+<span class="upd-date">Updated:&nbsp;&nbsp;<strong>30 November 2015</strong></span><span class="hpad">/</span>
+<span class="upd-officer">Responsible Officer:&nbsp;&nbsp;<a href="mailto:library.web@anu.edu.au"><strong>University Librarian</strong></a></span><span class="hpad">/</span>
+<span class="upd-contact">Page Contact:&nbsp;&nbsp;<a href="mailto:repository.admin@au.edu.au"><strong>Library Systems & Web Coordinator</strong></a></span>
+</p>
+</div>
+</div>
+<!-- endnoindex -->
+</div>
+</div>
+<!-- noindex -->
+<div id="footer-wrap" role="contentinfo">
+<div id="anu-footer">
+<div id="anu-detail">
+<ul>
+<li><a href="http://www.anu.edu.au/contact/">Contact ANU</a></li>
+<li><a href="http://campusmap.anu.edu.au/">Campus Map</a></li>
+<li><a href="http://www.anu.edu.au/mobile/">Mobile</a></li>
+<li><a href="http://legaloffice.weblogs.anu.edu.au/content/copyright/">Copyright</a></li>
+<li><a href="http://legaloffice.weblogs.anu.edu.au/content/copyright/#disclaimer">Disclaimer</a></li>
+<li><a href="http://legaloffice.weblogs.anu.edu.au/content/copyright/#privacy">Privacy</a></li>
+<li><a href="http://foi.anu.edu.au/">Freedom of Information</a></li>
+</ul>
+</div>
+<div id="anu-address">
+<p>+61 2 6125 5111<br/>
+The Australian National University, Canberra<br/>
+CRICOS Provider : 00120C<br/>
+ABN : 52 234 063 906</p>
+</div>
+<div id="anu-groups">
+<div class="anu-ftr-go8 hpad vpad"><a href="https://go8.edu.au/"><img class="text-white" src="//style.anu.edu.au/_anu/4/images/logos/2x_GroupOf8.png" alt="Group of Eight Member" /></a></div>
+<div class="anu-ftr-iaru hpad vpad"><a href="http://drss.anu.edu.au/isa/alliances.php"><img class="text-white" src="//style.anu.edu.au/_anu/4/images/logos/2x_iaru.png" alt="IARU" /></a></div>
+<div class="anu-ftr-apru hpad vpad"><a href="http://about.anu.edu.au/alliance-partner/apru"><img class="text-white" src="//style.anu.edu.au/_anu/4/images/logos/2x_apru.png" alt="APRU" /></a></div>
+<div class="anu-ftr-edx hpad vpad"><a href="https://www.edx.org"><img class="text-white" src="//style.anu.edu.au/_anu/4/images/logos/2x_edx.png" alt="edX" /></a></div>
+</div>
+</div>
+</div>
+</body>
+<!-- endnoindex -->
+</html>
+    </body>
+</html>
+</div>

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -101,7 +101,7 @@ def test_title(record):
 
 def test_date_published(record):
     """Test extracting date_published."""
-    date_published = "2013-05-09T05:16:48Z"
+    date_published = "2013-05-09"
     assert record['date_published']
     assert record['date_published'] == date_published
 

--- a/tests/test_dateutils.py
+++ b/tests/test_dateutils.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of hepcrawl.
+# Copyright (C) 2016 CERN.
+#
+# hepcrawl is a free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see LICENSE file for
+# more details.
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+
+import pytest
+
+from hepcrawl.dateutils import format_date, format_year
+
+
+@pytest.fixture
+def dates():
+    """Return list of tuples of formatted year and date."""
+    dates = {}
+    raw_dates = ["2013-05-09T05:16:48Z", "1973", "1916 Mar 4", "2014-2", "2012-5-55",
+            "2012 Feb", "1 May 1992", "5-2022", "5-222HH", 1995, "today", "1988/05/26"]
+    
+    for raw_date in raw_dates:
+        dates[raw_date] = format_year(raw_date), format_date(raw_date)
+    return dates 
+
+
+def test_dates(dates):
+    """Test that the date formatter function formats the dates and years
+    correctly."""
+    assert dates
+    assert dates["2013-05-09T05:16:48Z"] == (2013, '2013-05-09')
+    assert dates["1973"] == (1973, '1973')
+    assert dates["1916 Mar 4"] == (1916, '1916-03-04') 
+    assert dates["2014-2"] == (2014, '2014-02')
+    assert dates["2012-5-55"] == (2012, '2012-05')
+    assert dates["2012 Feb"] == (2012, '2012-02')
+    assert dates["1 May 1992"] == (1992, '1992-05-01')
+    assert dates["5-2022"] == (2022, '2022-05-01')
+    assert dates["5-222HH"] == (0, '5-222HH')
+    assert dates[1995] == (1995, '1995')
+    assert dates["today"] == (0, 'today')
+    assert dates["1988/05/26"] == (1988, '1988-05-26')

--- a/tests/test_elsevier.py
+++ b/tests/test_elsevier.py
@@ -61,21 +61,21 @@ def parsed_node():
             <oa:userLicense xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">http://creativecommons.org/licenses/by/3.0/</oa:userLicense>
         </oa:openAccessInformation>
         <rdf:Description rdf:about="http://dx.doi.org/10.1016/0370-2693(88)91603-6">
-                <dct:title>Toward classification of conformal theories</dct:title>
-                <prism:doi>10.1016/0370-2693(88)91603-6</prism:doi>
-                <prism:startingPage>421</prism:startingPage>
-                <prism:publicationName>Physics Letters, Section B</prism:publicationName>
-                <prism:volume>206</prism:volume>
-                <dct:creator>Cumrun Vafa</dct:creator>
-                <dct:subject>
-                    <rdf:Bag>
-                        <rdf:li>Heavy quarkonia</rdf:li>
-                        <rdf:li>Quark gluon plasma</rdf:li>
-                        <rdf:li>Mott effect</rdf:li>
-                        <rdf:li>X(3872)</rdf:li>
-                    </rdf:Bag>
-                </dct:subject>
-            </rdf:Description>
+            <dct:title>Toward classification of conformal theories</dct:title>
+            <prism:doi>10.1016/0370-2693(88)91603-6</prism:doi>
+            <prism:startingPage>421</prism:startingPage>
+            <prism:publicationName>Physics Letters, Section B</prism:publicationName>
+            <prism:volume>206</prism:volume>
+            <dct:creator>Cumrun Vafa</dct:creator>
+            <dct:subject>
+                <rdf:Bag>
+                    <rdf:li>Heavy quarkonia</rdf:li>
+                    <rdf:li>Quark gluon plasma</rdf:li>
+                    <rdf:li>Mott effect</rdf:li>
+                    <rdf:li>X(3872)</rdf:li>
+                </rdf:Bag>
+            </dct:subject>
+        </rdf:Description>
     </doc>"""
 
     response = fake_response_from_string(body)
@@ -128,62 +128,68 @@ def test_get_sd_url(sd_url):
 
 @pytest.fixture
 def cover_display_date():
+    """Parse and build the record with only date (day, month and year)."""
     spider = elsevier_spider.ElsevierSpider()
     body = """
-        <doc xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-            xmlns:prism="http://prismstandard.org/namespaces/basic/2.0/">
+    <doc xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:prism="http://prismstandard.org/namespaces/basic/2.0/">
         <rdf:Description>
-                <prism:coverDisplayDate>1 December 2014</prism:coverDisplayDate>
-            </rdf:Description>
+            <prism:coverDisplayDate>1 December 2014</prism:coverDisplayDate>
+        </rdf:Description>
     </doc>"""
 
     node = get_node(spider, '/doc', text=body)
-    return spider.get_date(node)
+    response = fake_response_from_string(body)
+    return spider.parse_node(response, node)
 
 def test_cover_display_date(cover_display_date):
-    year, date_published = cover_display_date
+    """Test coverDisplayDate and correct formatting with day, year and month."""
     assert cover_display_date
-    assert year == 2014
-    assert date_published == '2014-12-01'
+    assert cover_display_date["journal_year"] == 2014
+    assert cover_display_date["date_published"] == '2014-12-01'
 
 
 @pytest.fixture
 def cover_display_date_y_m():
+    """Parse and build the record with only date (month and year)."""
     spider = elsevier_spider.ElsevierSpider()
     body = """
-        <doc xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-            xmlns:prism="http://prismstandard.org/namespaces/basic/2.0/">
+    <doc xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:prism="http://prismstandard.org/namespaces/basic/2.0/">
         <rdf:Description>
-                <prism:coverDisplayDate>December 2014</prism:coverDisplayDate>
-            </rdf:Description>
+            <prism:coverDisplayDate>December 2014</prism:coverDisplayDate>
+        </rdf:Description>
     </doc>"""
     node = get_node(spider, '/doc', text=body)
-    return spider.get_date(node)
+    response = fake_response_from_string(body)
+    return spider.parse_node(response, node)
 
 def test_cover_display_date_y_m(cover_display_date_y_m):
-    year, date_published = cover_display_date_y_m
+    """Test coverDisplayDate and correct formatting with only year and month."""
     assert cover_display_date_y_m
-    assert year == 2014
-    assert date_published == '2014-12'
-    
+    assert cover_display_date_y_m["journal_year"] == 2014
+    assert cover_display_date_y_m["date_published"] == '2014-12'
+
 @pytest.fixture
 def cover_display_date_y():
+    """Parse and build the record with only date (year)."""
     spider = elsevier_spider.ElsevierSpider()
     body = """
-        <doc xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-            xmlns:prism="http://prismstandard.org/namespaces/basic/2.0/">
+    <doc xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:prism="http://prismstandard.org/namespaces/basic/2.0/">
         <rdf:Description>
-                <prism:coverDisplayDate>2014</prism:coverDisplayDate>
-            </rdf:Description>
+            <prism:coverDisplayDate>2014</prism:coverDisplayDate>
+        </rdf:Description>
     </doc>"""
     node = get_node(spider, '/doc', text=body)
-    return spider.get_date(node)
+    response = fake_response_from_string(body)
+    return spider.parse_node(response, node)
 
 def test_cover_display_date_y(cover_display_date_y):
-    year, date_published = cover_display_date_y
+    """Test coverDisplayDate and correct formatting with only year."""
     assert cover_display_date_y
-    assert year == 2014
-    assert date_published == '2014'
+    assert cover_display_date_y["journal_year"] == 2014
+    assert cover_display_date_y["date_published"] == '2014'
 
 @pytest.fixture(scope="module")
 def item_info():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,6 +26,7 @@ from hepcrawl.utils import (
     parse_domain,
     get_mime_type,
     has_numbers,
+    range_as_string,
 )
 
 
@@ -131,7 +132,7 @@ def test_split_fullname():
     assert split_fullname(author4, surname_first=False) == ('Doe', 'John Magic')
     assert split_fullname(author5, surname_first=False) == ('Boe', 'John Magic Doe')
     assert split_fullname(author6, surname_first=False) == ('Doe Boe', 'John Magic')
-    assert split_fullname(author7) == ('', '') 
+    assert split_fullname(author7) == ('', '')
 
 
 def test_parse_domain():
@@ -164,5 +165,19 @@ def test_has_numbers():
     """Test number detection"""
     text1 = "154 numbers"
     text2 = "no numbers"
-    assert has_numbers(text1) == True
-    assert has_numbers(text2) == False
+    assert has_numbers(text1) is True
+    assert has_numbers(text2) is False
+
+
+def test_range_as_string():
+    """Test range detection in a list of (string) integers."""
+    years1 = ["1981", "1982", "1983"]
+    years2 = ["1981", "1982", "1985"]
+    years3 = ["1981", "1989", "1995"]
+    years4 = ["1981", "1982", "1989", "2015", "2016"]
+    years5 = [500, 501, 600]
+    assert range_as_string(years1) == "1981-1983"
+    assert range_as_string(years2) == "1981-1982, 1985"
+    assert range_as_string(years3) == "1981, 1989, 1995"
+    assert range_as_string(years4) == "1981-1982, 1989, 2015-2016"
+    assert range_as_string(years5) == "500-501, 600"


### PR DESCRIPTION
The improved date getter/formatter.  I have tested it here with Elsevier and BASE spiders.

* How should the code be organised? Right now everything's happening in `dateutils.py`.

* Should the date formatting happen in the spider or in the loader? At least with `elsevier_spider`
  it's more convenient to be inside the spider as I'm getting the year at the same time.
