### PR TITLE
loaders: ensure only single source string

### DIFF
--- a/hepcrawl/loaders.py
+++ b/hepcrawl/loaders.py
@@ -48,6 +48,8 @@ class HEPLoader(ItemLoader):
     TakeFirst is used when only one item is expected to just take the first item
     in the list.
     """
+    source_out = TakeFirst()
+
     authors_in = MapCompose(
         parse_authors,
         clean_tags_from_affiliations,

--- a/tests/test_dnb.py
+++ b/tests/test_dnb.py
@@ -142,7 +142,7 @@ def test_supervisors(record):
 
 def test_source(record):
     """Test thesis source"""
-    source = [u'Univ.-Bibliothek Frankfurt am Main']
+    source = 'Univ.-Bibliothek Frankfurt am Main'
     assert record["source"]
     assert record["source"] == source
 


### PR DESCRIPTION
* Makes the source field always a string by taking the first
  item in case source is set to a list.

Signed-off-by: Jan Aage Lavik <jan.age.lavik@cern.ch>