### PR TITLE
pipelines: INSPIRE push update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,5 +49,11 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 
+# Scrapy
+jobs
+dbs
+items
+logs
+
 # Local settings
 local_settings.py

--- a/hepcrawl/pipelines.py
+++ b/hepcrawl/pipelines.py
@@ -59,7 +59,10 @@ class JsonWriterPipeline(object):
         ))
 
     def process_item(self, item, spider):
-        line = json.dumps(dict(item), indent=4) + ",\n"
+        line = ""
+        if self.count > 0:
+            line = "\n,"
+        line += json.dumps(dict(item), indent=4)
         self.file.write(line)
         self.count += 1
         return item

--- a/hepcrawl/settings.py
+++ b/hepcrawl/settings.py
@@ -95,6 +95,10 @@ CELERY_ACCEPT_CONTENT = ['json', 'msgpack', 'yaml']
 CELERY_TIMEZONE = 'Europe/Amsterdam'
 CELERY_DISABLE_RATE_LIMITS = True
 
+# Jobs
+# ====
+JOBDIR = "jobs"
+
 # Enable and configure the AutoThrottle extension (disabled by default)
 # See http://doc.scrapy.org/en/latest/topics/autothrottle.html
 # NOTE: AutoThrottle will honour the standard settings for concurrency and delay

--- a/hepcrawl/settings.py
+++ b/hepcrawl/settings.py
@@ -17,6 +17,9 @@ http://scrapy.readthedocs.org/en/latest/topics/downloader-middleware.html
 http://scrapy.readthedocs.org/en/latest/topics/spider-middleware.html
 """
 
+import os
+
+
 BOT_NAME = 'hepcrawl'
 
 SPIDER_MODULES = ['hepcrawl.spiders']
@@ -69,15 +72,29 @@ SENTRY_DSN = ''
 
 # Configure item pipelines
 # See http://scrapy.readthedocs.org/en/latest/topics/item-pipeline.html
+ITEM_PIPELINES = {
+    # 'hepcrawl.pipelines.JsonWriterPipeline': 300,
+    'hepcrawl.pipelines.InspireCeleryPushPipeline': 300,
+}
+
 
 API_PIPELINE_URL = ""
 API_PIPELINE_TASK_ENDPOINT_DEFAULT = ""
 API_PIPELINE_TASK_ENDPOINT_MAPPING = {}   # e.g. {'my_spider': 'special.task'}
 
-ITEM_PIPELINES = {
-    # 'hepcrawl.pipelines.JsonWriterPipeline': 300,
-    'hepcrawl.pipelines.InspireAPIPushPipeline': 300,
-}
+# Celery
+# ======
+BROKER_URL = os.environ.get(
+    "BROKER_URL",
+    "amqp://guest:guest@localhost:5672//")
+CELERY_RESULT_BACKEND = os.environ.get(
+    "CELERY_RESULT_BACKEND",
+    "amqp://guest:guest@localhost:5672//")
+CELERY_ACCEPT_CONTENT = ['json', 'msgpack', 'yaml']
+CELERY_TIMEZONE = 'Europe/Amsterdam'
+CELERY_DISABLE_RATE_LIMITS = True
+
+
 
 # Enable and configure the AutoThrottle extension (disabled by default)
 # See http://doc.scrapy.org/en/latest/topics/autothrottle.html

--- a/hepcrawl/settings.py
+++ b/hepcrawl/settings.py
@@ -25,31 +25,33 @@ BOT_NAME = 'hepcrawl'
 SPIDER_MODULES = ['hepcrawl.spiders']
 NEWSPIDER_MODULE = 'hepcrawl.spiders'
 
-# Crawl responsibly by identifying yourself (and your website) on the user-agent
+# Crawl responsibly by identifying yourself (and your website) on the
+# user-agent
 USER_AGENT = 'hepcrawl (+http://www.inspirehep.net)'
 
 # Configure maximum concurrent requests performed by Scrapy (default: 16)
-#CONCURRENT_REQUESTS=32
+# CONCURRENT_REQUESTS=32
 
 # Configure a delay for requests for the same website (default: 0)
-# See http://scrapy.readthedocs.org/en/latest/topics/settings.html#download-delay
+# See
+# http://scrapy.readthedocs.org/en/latest/topics/settings.html#download-delay
 # See also autothrottle settings and docs
-#DOWNLOAD_DELAY=3
+# DOWNLOAD_DELAY=3
 # The download delay setting will honor only one of:
-#CONCURRENT_REQUESTS_PER_DOMAIN=16
-#CONCURRENT_REQUESTS_PER_IP=16
+# CONCURRENT_REQUESTS_PER_DOMAIN=16
+# CONCURRENT_REQUESTS_PER_IP=16
 
 # Disable cookies (enabled by default)
-#COOKIES_ENABLED=False
+# COOKIES_ENABLED=False
 
 # Disable Telnet Console (enabled by default)
-#TELNETCONSOLE_ENABLED=False
+# TELNETCONSOLE_ENABLED=False
 
 # Override the default request headers:
-#DEFAULT_REQUEST_HEADERS = {
-#   'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-#   'Accept-Language': 'en',
-#}
+# DEFAULT_REQUEST_HEADERS = {
+#  'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+#  'Accept-Language': 'en',
+# }
 
 # Enable or disable spider middlewares
 # See http://scrapy.readthedocs.org/en/latest/topics/spider-middleware.html
@@ -77,7 +79,6 @@ ITEM_PIPELINES = {
     'hepcrawl.pipelines.InspireCeleryPushPipeline': 300,
 }
 
-
 API_PIPELINE_URL = ""
 API_PIPELINE_TASK_ENDPOINT_DEFAULT = ""
 API_PIPELINE_TASK_ENDPOINT_MAPPING = {}   # e.g. {'my_spider': 'special.task'}
@@ -94,26 +95,24 @@ CELERY_ACCEPT_CONTENT = ['json', 'msgpack', 'yaml']
 CELERY_TIMEZONE = 'Europe/Amsterdam'
 CELERY_DISABLE_RATE_LIMITS = True
 
-
-
 # Enable and configure the AutoThrottle extension (disabled by default)
 # See http://doc.scrapy.org/en/latest/topics/autothrottle.html
 # NOTE: AutoThrottle will honour the standard settings for concurrency and delay
-#AUTOTHROTTLE_ENABLED=True
+# AUTOTHROTTLE_ENABLED=True
 # The initial download delay
-#AUTOTHROTTLE_START_DELAY=5
+# AUTOTHROTTLE_START_DELAY=5
 # The maximum download delay to be set in case of high latencies
-#AUTOTHROTTLE_MAX_DELAY=60
+# AUTOTHROTTLE_MAX_DELAY=60
 # Enable showing throttling stats for every response received:
-#AUTOTHROTTLE_DEBUG=False
+# AUTOTHROTTLE_DEBUG=False
 
 # Enable and configure HTTP caching (disabled by default)
 # See http://scrapy.readthedocs.org/en/latest/topics/downloader-middleware.html#httpcache-middleware-settings
-#HTTPCACHE_ENABLED=True
-#HTTPCACHE_EXPIRATION_SECS=0
-#HTTPCACHE_DIR='httpcache'
-#HTTPCACHE_IGNORE_HTTP_CODES=[]
-#HTTPCACHE_STORAGE='scrapy.extensions.httpcache.FilesystemCacheStorage'
+# HTTPCACHE_ENABLED=True
+# HTTPCACHE_EXPIRATION_SECS=0
+# HTTPCACHE_DIR='httpcache'
+# HTTPCACHE_IGNORE_HTTP_CODES=[]
+# HTTPCACHE_STORAGE='scrapy.extensions.httpcache.FilesystemCacheStorage'
 
 try:
     from local_settings import *

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ readme = open('README.rst').read()
 history = open('CHANGES.rst').read()
 
 requirements = [
-    'Scrapy>=1.0.3',
+    'Scrapy>=1.1.0',
     'scrapyd>=1.1.0',
     'scrapyd-client>=1.0.1',
     'six>=1.9.0',

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ requirements = [
     'six>=1.9.0',
     'HarvestingKit>=0.6.3',
     'requests>=2.8.1',
+    'celery>=3.1.23',
 ]
 
 test_requirements = [


### PR DESCRIPTION
* Updates INSPIRE push mechanism to use Celery's send_task
  API instead of flower HTTP API.

Signed-off-by: Jan Aage Lavik <jan.age.lavik@cern.ch>