### PR TITLE
spiders: fix issue with scrapy selectors in request.meta

### DIFF
--- a/hepcrawl/utils.py
+++ b/hepcrawl/utils.py
@@ -19,6 +19,8 @@ from tempfile import mkstemp
 from zipfile import ZipFile
 from urlparse import urlparse
 
+from scrapy import Selector
+
 
 def unzip_xml_files(filename, target_folder):
     """Unzip files (XML only) into target folder."""
@@ -181,3 +183,12 @@ def range_as_string(data):
         else:
             ranges.append(str(group[0]))
     return ", ".join(ranges)
+
+
+def get_node(text, namespaces=None):
+    """Get a scrapy selector for the given text node."""
+    node = Selector(text=text, type="xml")
+    if namespaces:
+        for ns in namespaces:
+            node.register_namespace(ns[0], ns[1])
+    return node

--- a/tests/test_dnb.py
+++ b/tests/test_dnb.py
@@ -26,7 +26,7 @@ def record():
     selector = Selector(response, type="xml")
     spider._register_namespaces(selector)
     nodes = selector.xpath("//%s" % spider.itertag)
-    response.meta["node"] = nodes[0]
+    response.meta["record"] = nodes[0].extract()
     response.meta["direct_links"] = ["http://d-nb.info/1079912991/34"]
     response.meta["urls"] = [
         "http://nbn-resolving.de/urn:nbn:de:hebis:30:3-386257",
@@ -104,7 +104,7 @@ def splash():
     response.meta["urls"] = ["http://nbn-resolving.de/urn:nbn:de:hebis:30:3-386257",
                             "http://d-nb.info/1079912991/34",
                             "http://publikationen.ub.uni-frankfurt.de/frontdoor/index/index/docId/38625"]
-    response.meta["node"] = nodes[0]
+    response.meta["record"] = nodes[0].extract()
 
     return spider.scrape_for_abstract(response)
 


### PR DESCRIPTION
* It's no longer acceptable to attach selectors to scrapy requests.
* Adds new utils function `get_node`.
* The issue affected DNB and BASE spiders, they are now fixed.