### PR TITLE
packaging: use scrapyd for the scrapyd-deploy conf

### DIFF
--- a/scrapy.cfg
+++ b/scrapy.cfg
@@ -14,7 +14,7 @@
 default = hepcrawl.settings
 
 [deploy]
-url = http://localhost:6800/
+url = http://scrapyd:6800/
 project = hepcrawl
 #username = scrapy
 #password = secret


### PR DESCRIPTION
* As we are not really using it anywhere for the tests or anything,
  the generic 'scrapyd' name is more informative and more flexible.

Signed-off-by: David Caro <david@dcaro.es>