### PR TITLE
pipelines: send data payload through api

### DIFF
--- a/tests/responses/aps/aps_single_parsed.json
+++ b/tests/responses/aps/aps_single_parsed.json
@@ -1,0 +1,134 @@
+{
+    "errors": [], 
+    "results_uri": "scrapy_feed_uri", 
+    "log_file": "scrapy_log_file", 
+    "results_data": [
+        {
+            "page_nr": [
+                "11"
+            ], 
+            "acquisition_source": {
+                "date": "2017-02-07T23:18:39.078782", 
+                "source": "TestSpider", 
+                "method": "TestSpider", 
+                "submission_number": "scrapy_job"
+            }, 
+            "license": [
+                {
+                    "url": "http://creativecommons.org/licenses/by/3.0/", 
+                    "license": "CC-BY-3.0"
+                }
+            ], 
+            "collaborations": [
+                {
+                    "value": "OSQAR Collaboration"
+                }
+            ], 
+            "dois": [
+                {
+                    "value": "10.1103/PhysRevE.92.052801"
+                }
+            ], 
+            "titles": [
+                {
+                    "source": "TestSpider", 
+                    "subtitle": "", 
+                    "title": "You can run, you can hide: The epidemiology and statistical mechanics of zombies"
+                }
+            ], 
+            "collections": [
+                {
+                    "primary": "HEP"
+                }, 
+                {
+                    "primary": "Citeable"
+                }, 
+                {
+                    "primary": "Published"
+                }
+            ], 
+            "authors": [
+                {
+                    "raw_name": "Alexander A. Alemi", 
+                    "affiliations": [
+                        {
+                            "value": "Laboratory of Atomic and Solid State Physics, Cornell University, Ithaca, New York 14853, USA"
+                        }
+                    ], 
+                    "surname": "Alemi", 
+                    "given_names": "Alexander A.", 
+                    "full_name": "Alemi, Alexander A."
+                }, 
+                {
+                    "raw_name": "Matthew Bierbaum", 
+                    "affiliations": [
+                        {
+                            "value": "Laboratory of Atomic and Solid State Physics, Cornell University, Ithaca, New York 14853, USA"
+                        }
+                    ], 
+                    "surname": "Bierbaum", 
+                    "given_names": "Matthew", 
+                    "full_name": "Bierbaum, Matthew"
+                }, 
+                {
+                    "raw_name": "Christopher R. Myers", 
+                    "affiliations": [
+                        {
+                            "value": "Laboratory of Atomic and Solid State Physics, Cornell University, Ithaca, New York 14853, USA"
+                        }, 
+                        {
+                            "value": "Institute of Biotechnology, Cornell University, Ithaca, New York 14853, USA"
+                        }
+                    ], 
+                    "surname": "Myers", 
+                    "given_names": "Christopher R.", 
+                    "full_name": "Myers, Christopher R."
+                }, 
+                {
+                    "raw_name": "James P. Sethna", 
+                    "affiliations": [
+                        {
+                            "value": "Laboratory of Atomic and Solid State Physics, Cornell University, Ithaca, New York 14853, USA"
+                        }
+                    ], 
+                    "surname": "Sethna", 
+                    "given_names": "James P.", 
+                    "full_name": "Sethna, James P."
+                }
+            ], 
+            "publication_info": [
+                {
+                    "journal_volume": "92", 
+                    "note": "", 
+                    "page_end": "", 
+                    "artid": "", 
+                    "journal_title": "Phys. Rev. E", 
+                    "pubinfo_freetext": "", 
+                    "page_start": "", 
+                    "year": 2015, 
+                    "journal_issue": "5"
+                }
+            ], 
+            "copyright": [
+                {
+                    "material": "Article", 
+                    "holder": "authors", 
+                    "statement": "Published by the American Physical Society", 
+                    "year": "2015"
+                }
+            ], 
+            "abstracts": [
+                {
+                    "source": "TestSpider", 
+                    "value": "We use a popular fictional disease, zombies, in order to introduce techniques used in modern epidemiology modeling, and ideas and techniques used in the numerical study of critical phenomena. We consider variants of zombie models, from fully connected continuous time dynamics to a full scale exact stochastic dynamic simulation of a zombie outbreak on the continental United States. Along the way, we offer a closed form analytical expression for the fully connected differential equation, and demonstrate that the single person per site two dimensional square lattice version of zombies lies in the percolation universality class. We end with a quantitative study of the full scale US outbreak, including the average susceptibility of different geographical regions."
+                }
+            ], 
+            "imprints": [
+                {
+                    "date": "2015-11-02"
+                }
+            ]
+        }
+    ], 
+    "job_id": "scrapy_job"
+}

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -9,7 +9,13 @@
 
 from __future__ import absolute_import, print_function, unicode_literals
 
+import json
+import mock
+import os
+
 import pytest
+
+from scrapy.spider import Spider
 
 from hepcrawl.spiders import aps_spider
 from hepcrawl.pipelines import InspireAPIPushPipeline, JsonWriterPipeline
@@ -18,31 +24,39 @@ from .responses import fake_response_from_file
 
 
 @pytest.fixture
+def spider():
+    mock_spider = mock.create_autospec(Spider)
+    mock_spider.name = 'TestSpider'
+    mock_spider.state = {}
+    return mock_spider
+
+
+@pytest.fixture
 def json_spider_record(tmpdir):
     from scrapy.http import TextResponse
     spider = aps_spider.APSSpider()
-    items = spider.parse(fake_response_from_file('aps/aps_single_response.json', response_type=TextResponse))
+    items = spider.parse(
+        fake_response_from_file(
+            'aps/aps_single_response.json',
+            response_type=TextResponse,
+        ),
+    )
     parsed_record = items.next()
     assert parsed_record
     return spider, parsed_record
 
 
 @pytest.fixture
-def inspire_record():
-    """Return results from the pipeline."""
-    from scrapy.http import TextResponse
-
-    spider = aps_spider.APSSpider()
-    items = spider.parse(
-        fake_response_from_file(
-            'aps/aps_single_response.json',
-            response_type=TextResponse
-        )
+def expected_response():
+    responses_dir = os.path.dirname(os.path.realpath(__file__))
+    expected_path = os.path.join(
+        responses_dir,
+        'responses/aps/aps_single_parsed.json',
     )
-    parsed_record = items.next()
-    pipeline = InspireAPIPushPipeline()
-    assert parsed_record
-    return pipeline.process_item(parsed_record, spider)
+    with open(expected_path, 'rb') as expected_fd:
+        result = expected_fd.read()
+
+    return json.loads(result)
 
 
 def test_json_output(tmpdir, json_spider_record):
@@ -60,3 +74,26 @@ def test_json_output(tmpdir, json_spider_record):
     json_pipeline.close_spider(spider)
 
     assert tmpfile.read()
+
+
+def test_prepare_payload(
+    tmpdir, json_spider_record, spider, expected_response,
+):
+    """Test that the generated payload is ok."""
+    _, json_record = json_spider_record
+    os.environ['SCRAPY_JOB'] = 'scrapy_job'
+    os.environ['SCRAPY_FEED_URI'] = 'scrapy_feed_uri'
+    os.environ['SCRAPY_LOG_FILE'] = 'scrapy_log_file'
+
+    pipeline = InspireAPIPushPipeline()
+
+    pipeline.open_spider(spider)
+    pipeline.process_item(json_record, spider)
+
+    result = pipeline._prepare_payload(spider)
+
+    # acquisition_source has a timestamp
+    result['results_data'][0]['acquisition_source'].pop('date')
+    expected_response['results_data'][0]['acquisition_source'].pop('date')
+
+    assert result == expected_response


### PR DESCRIPTION
* Now when using the inspire pipelines, it will create a temporary
  file to store all the results (independent from any other pipelines)
  and send that as data payload (json encoded) to the endpoint task
  plus the path to the 'persistent storage' uri, that might be slow to
  access or not even exist at the time the submit task runs but will
  eventually get created.

Signed-off-by: David Caro <david@dcaro.es>