### PR TITLE
TLS URL adjustments for PoS

### DIFF
--- a/hepcrawl/spiders/pos_spider.py
+++ b/hepcrawl/spiders/pos_spider.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of hepcrawl.
-# Copyright (C) 2016 CERN.
+# Copyright (C) 2016, 2017 CERN.
 #
 # hepcrawl is a free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for
@@ -13,6 +13,7 @@ import re
 
 from scrapy import Request, Selector
 from scrapy.spiders import Spider
+from urlparse import urljoin
 from ..utils import get_license, get_first
 from ..dateutils import create_valid_date
 from ..items import HEPRecord
@@ -32,7 +33,7 @@ class POSSpider(Spider):
 
     """
     name = 'PoS'
-    pos_base_url = "http://pos.sissa.it/contribution?id="
+    pos_base_url = "https://pos.sissa.it/contribution?id="
 
     def __init__(self, source_file=None, **kwargs):
         """Construct POS spider."""
@@ -61,6 +62,7 @@ class POSSpider(Spider):
         response.meta["pos_pdf_url"] = response.selector.xpath(
             "//a[contains(text(),'pdf')]/@href"
         ).extract_first()
+        response.meta["pos_pdf_url"] = urljoin(self.pos_base_url, response.meta["pos_pdf_url"])
         response.meta["pos_url"] = response.url
         return self.build_item(response)
 

--- a/tests/responses/pos/sample_pos_record.xml
+++ b/tests/responses/pos/sample_pos_record.xml
@@ -2,7 +2,7 @@
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
 <responseDate>2015-01-29T13:44:13Z</responseDate>
 <request verb="ListRecords" metadataPrefix="pos-ext_dc" set="conference:LATTICE 2013">
-http://pos.sissa.it/cgi-bin/oai/oai-script-spires-extended.cgi
+https://pos.sissa.it/cgi-bin/oai/oai-script-spires-extended.cgi
 </request>
 <ListRecords>
     <record>

--- a/tests/responses/pos/sample_splash_page.html
+++ b/tests/responses/pos/sample_splash_page.html
@@ -36,7 +36,7 @@ A. El-Khadra</div>
 
 <div>
   <em>Contribution</em>
-  <strong><a href="http://pos.sissa.it/archive/conferences/187/001/LATTICE 2013_001.pdf">pdf</a></strong>
+  <strong><a href="https://pos.sissa.it/archive/conferences/187/001/LATTICE 2013_001.pdf">pdf</a></strong>
 </div>
 
 


### PR DESCRIPTION
PoS/Sissa switched to all `https:` after breakin in late 2016.
This patch simply updates the URLs.

In addition PDF links can be relative links and this patch uses `urlparse.urljoin()` to construct valid absolute URL

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>