### PR TITLE
WSP: introduce public_notes to spider

### DIFF
--- a/hepcrawl/extractors/jats.py
+++ b/hepcrawl/extractors/jats.py
@@ -68,6 +68,16 @@ class Jats(object):
                     free_keywords.append(keyword)
         return free_keywords, classification_numbers
 
+    def _get_public_notes(self, node):
+        """Return list of public notes from node."""
+        public_notes = []
+        for note in node.xpath('//notes[@notes-type]'):
+            for keyword in note.xpath('p/text()').extract():
+                public_notes.append({
+                    'value': keyword,
+                })
+        return public_notes
+
     def _get_authors(self, node):
         authors = []
         for contrib in node.xpath(".//contrib[@contrib-type='author']"):

--- a/hepcrawl/spiders/wsp_spider.py
+++ b/hepcrawl/spiders/wsp_spider.py
@@ -151,6 +151,7 @@ class WorldScientificSpider(Jats, XMLFeedSpider):
             record.add_value('journal_doctype', article_type)
         record.add_xpath('dois', "//article-id[@pub-id-type='doi']/text()")
         record.add_xpath('page_nr', "//counts/page-count/@count")
+        record.add_value('public_notes', self._get_public_notes(node))
 
         record.add_xpath('abstract', '//abstract[1]')
         record.add_xpath('title', '//article-title/text()')

--- a/tests/unit/test_world_scientific.py
+++ b/tests/unit/test_world_scientific.py
@@ -450,6 +450,12 @@ def test_pipeline_record(generated_record):
             },
         ],
         'number_of_pages': 6,
+        'public_notes': [
+            {
+                'source': 'hepcrawl',
+                'value': u'Communicated by J. John'
+            }
+        ],
         'publication_info': [
             {
                 'artid': u'1750006',

--- a/tests/unit/test_world_scientific.py
+++ b/tests/unit/test_world_scientific.py
@@ -441,7 +441,8 @@ def test_pipeline_record(generated_record):
         ],
         'dois': [
             {
-                'source': 'hepcrawl', 'value': u'10.1142/S0219025717500060',
+                'source': 'hepcrawl',
+                'value': u'10.1142/S0219025717500060',
             },
         ],
         'imprints': [


### PR DESCRIPTION
* Adds `public_notes` field for spiders.
* Updates WSP unit tests for `public_notes` field.
* Fixes minor indentation for WSP unit test.

Closes #117 

Signed-off-by: Spiros Delviniotis <spyridon.delviniotis@cern.ch>