### PR TITLE
pipelines: remove unused JsonWriterPipeline

### DIFF
--- a/hepcrawl/pipelines.py
+++ b/hepcrawl/pipelines.py
@@ -42,51 +42,6 @@ def filter_fields(item, keys):
         item.pop(key, None)
 
 
-class JsonWriterPipeline(object):
-    """Pipeline for outputting items in JSON lines format."""
-
-    def __init__(self, output_uri=None):
-        self.output_uri = output_uri
-        self.count = 0
-
-    @classmethod
-    def from_crawler(cls, crawler):
-        if crawler.spider is not None:
-            prefix = "{0}_".format(crawler.spider.name)
-        else:
-            prefix = "hepcrawl"
-
-        output_uri = get_temporary_file(
-            prefix=prefix,
-            suffix=".json",
-            directory=crawler.settings.get("JSON_OUTPUT_DIR")
-        )
-        return cls(
-            output_uri=output_uri,
-        )
-
-    def open_spider(self, spider):
-        self.file = open(self.output_uri, "wb")
-        self.file.write("[")
-
-    def close_spider(self, spider):
-        self.file.write("]\n")
-        self.file.close()
-        spider.logger.info("Wrote {0} records to {1}".format(
-            self.count,
-            self.output_uri,
-        ))
-
-    def process_item(self, item, spider):
-        line = ""
-        if self.count > 0:
-            line = "\n,"
-        line += json.dumps(dict(item), indent=4)
-        self.file.write(line)
-        self.count += 1
-        return item
-
-
 class InspireAPIPushPipeline(object):
     """Push to INSPIRE API via tasks API."""
 

--- a/hepcrawl/settings.py
+++ b/hepcrawl/settings.py
@@ -83,7 +83,6 @@ if SENTRY_DSN:
 # Configure item pipelines
 # See http://scrapy.readthedocs.org/en/latest/topics/item-pipeline.html
 ITEM_PIPELINES = {
-    # 'hepcrawl.pipelines.JsonWriterPipeline': 300,
     'scrapy.pipelines.files.FilesPipeline': 1,
     'hepcrawl.pipelines.InspireCeleryPushPipeline': 300,
 }

--- a/tests/unit/test_pipelines.py
+++ b/tests/unit/test_pipelines.py
@@ -19,7 +19,7 @@ from scrapy.spider import Spider
 from inspire_schemas.api import validate
 
 from hepcrawl.spiders import arxiv_spider
-from hepcrawl.pipelines import InspireAPIPushPipeline, JsonWriterPipeline
+from hepcrawl.pipelines import InspireAPIPushPipeline
 
 from .responses import fake_response_from_file
 
@@ -58,23 +58,6 @@ def expected_response():
         result = expected_fd.read()
 
     return json.loads(result)
-
-
-def test_json_output(tmpdir, json_spider_record):
-    """Test writing results to a file."""
-    tmpfile = tmpdir.mkdir("json").join("aps.json")
-
-    spider, json_record = json_spider_record
-
-    json_pipeline = JsonWriterPipeline(output_uri=tmpfile.strpath)
-
-    assert json_pipeline.output_uri
-
-    json_pipeline.open_spider(spider)
-    json_pipeline.process_item(json_record, spider)
-    json_pipeline.close_spider(spider)
-
-    assert tmpfile.read()
 
 
 def test_prepare_payload(


### PR DESCRIPTION
* Removes unused `JsonWriterPipeline` and it's test.

Closes #102

Signed-off-by: Spiros Delviniotis <spyridon.delviniotis@cern.ch>