### PR TITLE
tests: add wsp unit test using the full pipeline output

### DIFF
--- a/hepcrawl/spiders/wsp_spider.py
+++ b/hepcrawl/spiders/wsp_spider.py
@@ -16,7 +16,6 @@ import urlparse
 
 from scrapy import Request
 from scrapy.spiders import XMLFeedSpider
-from inspire_schemas.api import validate as validate_schema
 
 from ..extractors.jats import Jats
 from ..items import HEPRecord
@@ -197,7 +196,6 @@ class WorldScientificSpider(Jats, XMLFeedSpider):
 
         record.add_value('collections', self._get_collections(node, article_type, journal_title))
         parsed_record = dict(record.load_item())
-        validate_schema(data=parsed_record, schema_name='hep')
 
         return parsed_record
 

--- a/tests/unit/responses/world_scientific/wsp_record.xml
+++ b/tests/unit/responses/world_scientific/wsp_record.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE article PUBLIC "-//Atypon//DTD Atypon JATS (Z39.96) Journal Archiving and Interchange DTD v1.0.4 20140502//EN" "Atypon-archivearticle1.dtd">
+<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" article-type="research-article" xml:lang="en" dtd-version="1.0">
+    <front>
+        <journal-meta>
+            <journal-id journal-id-type="publisher-id">idaqp</journal-id>
+            <journal-title-group>
+                <journal-title>This is a journal title 2</journal-title>
+            </journal-title-group>
+            <issn pub-type="ppub">0219-0257</issn>
+            <issn pub-type="epub">1793-6306</issn>
+            <publisher>
+                <publisher-name>Publisher name</publisher-name>
+            </publisher>
+        </journal-meta>
+        <article-meta>
+            <article-id pub-id-type="doi">10.1142/S0219025717500060</article-id>
+            <article-categories>
+                <subj-group subj-group-type="AMSC">
+                <subject>60H10</subject>
+                <subject>60J75</subject>
+                <subject>60J60</subject>
+                </subj-group>
+            </article-categories>
+            <title-group>
+                <article-title>Article-title’s</article-title>
+                <alt-title alt-title-type="left-running-head">Name_1. Surname_1</alt-title>
+                <alt-title alt-title-type="right-running-head">Right running head’s</alt-title>
+            </title-group>
+            <contrib-group>
+                <contrib contrib-type="author">
+                    <string-name name-style="western"><given-names>author_name_1</given-names> <surname>author_surname_2</surname></string-name>
+                    <xref ref-type="aff" rid="S0219025717500060AF001"><sup>1</sup></xref>
+                </contrib>
+            </contrib-group>
+            <aff id="S0219025717500060AF001"><label><sup>1</sup></label>Department, University, City, City_code 123456, <country>C. R. Country_2</country></aff>
+            <aff id="S0219025717500060EM001"><email>name_1@domain.com</email></aff>
+            <pub-date pub-type="ppub">
+                <month>30</month>
+                <year>2017</year>
+                <string-date>March 2017</string-date>
+            </pub-date>
+            <volume>30</volume>
+            <issue>01</issue>
+            <elocation-id>1750006</elocation-id>
+            <history>
+                <date date-type="received">
+                    <day>30</day>
+                    <month>04</month>
+                    <year>2016</year>
+                    <string-date>Received: 30 April 2016</string-date>
+                </date>
+                <date date-type="accepted">
+                    <day>30</day>
+                    <month>11</month>
+                    <year>2016</year>
+                    <string-date>Accepted: 30 November 2016</string-date>
+                </date>
+                    <date date-type="published">
+                    <day>30</day>
+                    <month>03</month>
+                    <year>2017</year>
+                    <string-date>Published: 30 March 2017</string-date>
+                </date>
+            </history>
+            <permissions>
+                <copyright-year>2017</copyright-year>
+                <copyright-holder>Copyright Holder</copyright-holder>
+            </permissions>
+            <self-uri content-type="pdf" xlink:href="s0219025717500060.pdf"></self-uri>
+            <abstract>
+                <p>Abstract Lévy bla-bla bla blaaa blaa bla blaaa blaa, bla blaaa blaa. Bla blaaa blaa.</p>
+            </abstract>
+            <kwd-group>
+                <kwd>Bla blaa</kwd>
+                <kwd>blabla</kwd>
+                <kwd>Blaa bla bla <inline-formula><mml:math display="inline" overflow="scroll"><mml:mi>W</mml:mi><mml:mo class="MathClass-open" stretchy="false">(</mml:mo><mml:mi>x</mml:mi><mml:mo class="MathClass-punc">;</mml:mo> <mml:mi>q</mml:mi><mml:mo class="MathClass-close" stretchy="false">)</mml:mo></mml:math></inline-formula></kwd>
+                <kwd>blq</kwd>
+            </kwd-group>
+            <counts>
+                <ref-count count="7"></ref-count>
+                <page-count count="6"></page-count>
+            </counts>
+        </article-meta>
+        <notes notes-type="communicated-by">
+            <p>Communicated by J. John</p>
+        </notes>
+    </front>
+</article>

--- a/tests/unit/test_world_scientific.py
+++ b/tests/unit/test_world_scientific.py
@@ -67,7 +67,6 @@ def override_generated_fields(record):
     return record
 
 
-@pytest.mark.xfail(reason='old schema')
 def test_abstract(results):
     """Test extracting abstract."""
     abstract = (
@@ -88,7 +87,6 @@ def test_abstract(results):
         assert record['abstract'] == abstract
 
 
-@pytest.mark.xfail(reason='old schema')
 def test_title(results):
     """Test extracting title."""
     title = "High-efficient Solid-state Perovskite Solar Cell Without Lithium Salt in the Hole Transport Material"
@@ -97,7 +95,6 @@ def test_title(results):
         assert record['title'] == title
 
 
-@pytest.mark.xfail(reason='old schema')
 def test_date_published(results):
     """Test extracting date_published."""
     date_published = "2014-06-05"
@@ -106,7 +103,6 @@ def test_date_published(results):
         assert record['date_published'] == date_published
 
 
-@pytest.mark.xfail(reason='old schema')
 def test_page_nr(results):
     """Test extracting page_nr"""
     page_nr = ["7"]
@@ -115,7 +111,6 @@ def test_page_nr(results):
         assert record['page_nr'] == page_nr
 
 
-@pytest.mark.xfail(reason='old schema')
 def test_free_keywords(results):
     """Test extracting free_keywords"""
     free_keywords = ['Perovskite CH$_{3}$NH$_{3}$PbI$_{3}$', 'solar cell', 'lithium']
@@ -127,7 +122,6 @@ def test_free_keywords(results):
             free_keywords.remove(keyword['value'])
 
 
-@pytest.mark.xfail(reason='old schema')
 def test_license(results):
     """Test extracting license information."""
     expected_license = [{
@@ -141,7 +135,6 @@ def test_license(results):
         assert record['license'] == expected_license
 
 
-@pytest.mark.xfail(reason='old schema')
 def test_dois(results):
     """Test extracting dois."""
     dois = "10.1142/S1793292014400013"
@@ -150,7 +143,6 @@ def test_dois(results):
         assert record['dois'][0]['value'] == dois
 
 
-@pytest.mark.xfail(reason='old schema')
 def test_collections(results):
     """Test extracting collections."""
     collections = ["HEP", "Published"]
@@ -160,7 +152,6 @@ def test_collections(results):
             assert {"primary": coll} in record['collections']
 
 
-@pytest.mark.xfail(reason='old schema')
 def test_collaborations(results):
     """Test extracting collaboration."""
     collaborations = [{"value": "Belle Collaboration"}]
@@ -169,7 +160,6 @@ def test_collaborations(results):
         assert record['collaborations'] == collaborations
 
 
-@pytest.mark.xfail(reason='old schema')
 def test_publication_info(results):
     """Test extracting dois."""
     journal_title = "NANO"
@@ -190,7 +180,6 @@ def test_publication_info(results):
         assert record['journal_issue'] == journal_issue
 
 
-@pytest.mark.xfail(reason='old schema')
 def test_authors(results):
     """Test authors."""
     authors = ["BI, DONGQIN", "BOSCHLOO, GERRIT", "HAGFELDT, ANDERS"]
@@ -213,7 +202,6 @@ def test_authors(results):
                 ]
 
 
-@pytest.mark.xfail(reason='old schema')
 def test_copyrights(results):
     """Test extracting copyright."""
     copyright_holder = "World Scientific Publishing Company"


### PR DESCRIPTION
* Removes duplicated validation for the item in WSP spider.
* Adds: WSP unit test that uses the full pipeline output. In that way all the tests will be really checking 
  that the produced data are schema compliant.
* Re-enables xfailed unit tests for WSP spider.

Closes #111

Signed-off-by: Spiros Delviniotis <spyridon.delviniotis@cern.ch>