### PR TITLE
tests: create environment handler fixture

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of hepcrawl.
+# Copyright (C) 2017 CERN.
+#
+# hepcrawl is a free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see LICENSE file for
+# more details.
+
+from __future__ import absolute_import, division, print_function
+
+import pytest
+import os
+
+
+@pytest.fixture(scope='session')
+def set_up_clean_up_env_vars():
+    env_var_backup = dict(os.environ)
+
+    os.environ['SCRAPY_JOB'] = 'scrapy_job'
+    os.environ['SCRAPY_FEED_URI'] = 'scrapy_feed_uri'
+    os.environ['SCRAPY_LOG_FILE'] = 'scrapy_log_file'
+
+    yield
+
+    os.environ = env_var_backup

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -13,14 +13,8 @@ import pytest
 import os
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope='function', autouse=True)
 def set_up_clean_up_env_vars():
     env_var_backup = dict(os.environ)
-
-    os.environ['SCRAPY_JOB'] = 'scrapy_job'
-    os.environ['SCRAPY_FEED_URI'] = 'scrapy_feed_uri'
-    os.environ['SCRAPY_LOG_FILE'] = 'scrapy_log_file'
-
     yield
-
     os.environ = env_var_backup

--- a/tests/unit/test_pipelines.py
+++ b/tests/unit/test_pipelines.py
@@ -61,10 +61,13 @@ def expected_response():
 
 
 def test_prepare_payload(
-    tmpdir, json_spider_record, spider, expected_response, set_up_clean_up_env_vars,
+    tmpdir, json_spider_record, spider, expected_response,
 ):
     """Test that the generated payload is ok."""
     _, json_record = json_spider_record
+    os.environ['SCRAPY_JOB'] = 'scrapy_job'
+    os.environ['SCRAPY_FEED_URI'] = 'scrapy_feed_uri'
+    os.environ['SCRAPY_LOG_FILE'] = 'scrapy_log_file'
 
     pipeline = InspireAPIPushPipeline()
 

--- a/tests/unit/test_pipelines.py
+++ b/tests/unit/test_pipelines.py
@@ -61,13 +61,10 @@ def expected_response():
 
 
 def test_prepare_payload(
-    tmpdir, json_spider_record, spider, expected_response,
+    tmpdir, json_spider_record, spider, expected_response, set_up_clean_up_env_vars,
 ):
     """Test that the generated payload is ok."""
     _, json_record = json_spider_record
-    os.environ['SCRAPY_JOB'] = 'scrapy_job'
-    os.environ['SCRAPY_FEED_URI'] = 'scrapy_feed_uri'
-    os.environ['SCRAPY_LOG_FILE'] = 'scrapy_log_file'
 
     pipeline = InspireAPIPushPipeline()
 


### PR DESCRIPTION
* Adds `tests/unit/conftest.py` module for unit tests fixtures.
* Adds fixture that sets up the env variables and at the end restores the previous environment.

Closes #113

Signed-off-by: Spiros Delviniotis <spyridon.delviniotis@cern.ch>