### PR TITLE
tests: update WSP unit tests - use pipeline output

### DIFF
--- a/tests/unit/test_world_scientific.py
+++ b/tests/unit/test_world_scientific.py
@@ -13,6 +13,7 @@ import pytest
 import os
 
 from scrapy.crawler import Crawler
+from scrapy.http import TextResponse
 
 from hepcrawl.pipelines import InspireCeleryPushPipeline
 from hepcrawl.spiders import wsp_spider
@@ -20,40 +21,35 @@ from hepcrawl.spiders import wsp_spider
 from .responses import fake_response_from_file
 
 
-@pytest.fixture
-def spider():
+def create_spider():
     crawler = Crawler(spidercls=wsp_spider.WorldScientificSpider)
     return wsp_spider.WorldScientificSpider.from_crawler(crawler)
 
 
-@pytest.fixture
-def all_results(request, spider):
+def get_records(response_file_name):
     """Return all results generator from the WSP spider via pipelines."""
-    from scrapy.http import TextResponse
-    
     # environmental variables needed for the pipelines payload
     os.environ['SCRAPY_JOB'] = 'scrapy_job'
     os.environ['SCRAPY_FEED_URI'] = 'scrapy_feed_uri'
     os.environ['SCRAPY_LOG_FILE'] = 'scrapy_log_file'
 
-    records = list(spider.parse(
+    spider = create_spider()
+    records = spider.parse(
         fake_response_from_file(
-            file_name=request.param,
+            file_name=response_file_name,
             response_type=TextResponse
         )
-    ))
+    )
 
     pipeline = InspireCeleryPushPipeline()
     pipeline.open_spider(spider)
 
-    return [pipeline.process_item(record, spider) for record in records]
+    return (pipeline.process_item(record, spider) for record in records)
 
 
-@pytest.fixture
-def one_result(spider, all_results):
-    """Return result one record generator from the WSP spider via pipelines.
-    Fixture `all_results` must be parametrized with the response `file_name`."""
-    return all_results[0]
+def get_one_record(response_file_name):
+    results = get_records(response_file_name)
+    return results.next()
 
 
 def override_generated_fields(record):
@@ -63,225 +59,353 @@ def override_generated_fields(record):
 
 
 @pytest.mark.parametrize(
-    'all_results',
-    ['world_scientific/sample_ws_record.xml'],
-    indirect=True
+    'generated_record, expected_abstract',
+    [
+        [
+            get_one_record('world_scientific/sample_ws_record.xml'),
+            (
+                "CH$_{3}$NH$_{3}$PbX(X = Br, I, Cl) perovskites have recently been used as light absorbers in hybrid"
+                " organic-inorganic solid-state solar cells, with efficiencies above 15%. To date, it is essential to"
+                " add Lithium bis(Trifluoromethanesulfonyl)Imide (LiTFSI) to the hole transport materials (HTM) to get"
+                " a higher conductivity. However, the detrimental effect of high LiTFSI concentration on the charge transport"
+                ", DOS in the conduction band of the TiO$_{2}$ substrate and device stability results in an overall "
+                "compromise for a satisfactory device. Using a higher mobility hole conductor to avoid lithium salt "
+                "is an interesting alternative. Herein, we successfully made an efficient perovskite solar cell by "
+                "applying a hole conductor PTAA (Poly[bis(4-phenyl) (2,4,6-trimethylphenyl)-amine]) in the absence of"
+                " LiTFSI. Under AM 1.5 illumination of 100 mW/cm$^{2}$, an efficiency of 10.9% was achieved, which is "
+                "comparable to the efficiency of 12.3% with the addition of 1.3 mM LiTFSI. An unsealed device without "
+                "Li$^{+}$ shows interestingly a promising stability."
+            ),
+        ],
+    ],
+    ids=[
+        'smoke',
+    ]
 )
-def test_abstract(all_results):
+def test_abstract(generated_record, expected_abstract):
     """Test extracting abstract."""
-    abstract = (
-        "CH$_{3}$NH$_{3}$PbX(X = Br, I, Cl) perovskites have recently been used as light absorbers in hybrid"
-        " organic-inorganic solid-state solar cells, with efficiencies above 15%. To date, it is essential to"
-        " add Lithium bis(Trifluoromethanesulfonyl)Imide (LiTFSI) to the hole transport materials (HTM) to get"
-        " a higher conductivity. However, the detrimental effect of high LiTFSI concentration on the charge transport"
-        ", DOS in the conduction band of the TiO$_{2}$ substrate and device stability results in an overall "
-        "compromise for a satisfactory device. Using a higher mobility hole conductor to avoid lithium salt "
-        "is an interesting alternative. Herein, we successfully made an efficient perovskite solar cell by "
-        "applying a hole conductor PTAA (Poly[bis(4-phenyl) (2,4,6-trimethylphenyl)-amine]) in the absence of"
-        " LiTFSI. Under AM 1.5 illumination of 100 mW/cm$^{2}$, an efficiency of 10.9% was achieved, which is "
-        "comparable to the efficiency of 12.3% with the addition of 1.3 mM LiTFSI. An unsealed device without "
-        "Li$^{+}$ shows interestingly a promising stability."
-    )
-    for record in all_results:
-        assert 'abstracts' in record
-        assert record['abstracts'][0]['value'] == abstract
+    assert 'abstracts' in generated_record
+    assert generated_record['abstracts'][0]['value'] == expected_abstract
 
 
 @pytest.mark.parametrize(
-    'all_results',
-    ['world_scientific/sample_ws_record.xml'],
-    indirect=True
+    'generated_record, expected_title',
+    [
+        [
+            get_one_record('world_scientific/sample_ws_record.xml'),
+            [{
+                'source': 'WSP',
+                'title': 'High-efficient Solid-state Perovskite Solar Cell Without Lithium Salt in the Hole Transport Material',
+            }],
+        ],
+    ],
+    ids=[
+        'smoke',
+    ]
 )
-def test_title(all_results):
+def test_title(generated_record, expected_title):
     """Test extracting title."""
-    title = "High-efficient Solid-state Perovskite Solar Cell Without Lithium Salt in the Hole Transport Material"
-    for record in all_results:
-        assert 'titles' in record
-        assert record['titles'][0]['title'] == title
+    assert 'titles' in generated_record
+    assert generated_record['titles'] == expected_title
 
 
 @pytest.mark.parametrize(
-    'all_results',
-    ['world_scientific/sample_ws_record.xml'],
-    indirect=True
+    'generated_record, expected_imprint',
+    [
+        [
+            get_one_record('world_scientific/sample_ws_record.xml'),
+            [{
+                'date': '2014-06-05T00:00:00',
+            }],
+        ],
+    ],
+    ids=[
+        'smoke',
+    ]
 )
-def test_imprints(all_results):
+def test_imprints(generated_record, expected_imprint):
     """Test extracting imprint."""
-    imprint = "2014-06-05T00:00:00"
-    for record in all_results:
-        assert 'imprints' in record
-        assert record['imprints'][0]['date'] == imprint
+    assert 'imprints' in generated_record
+    assert generated_record['imprints'] == expected_imprint
 
 
 @pytest.mark.parametrize(
-    'all_results',
-    ['world_scientific/sample_ws_record.xml'],
-    indirect=True
+    'generated_record, expected_number_of_pages',
+    [
+        [
+            get_one_record('world_scientific/sample_ws_record.xml'),
+            7,
+        ],
+    ],
+    ids=[
+        'smoke',
+    ]
 )
-def test_number_of_pages(all_results):
+def test_number_of_pages(generated_record, expected_number_of_pages):
     """Test extracting number_of_pages"""
-    number_of_pages = 7
-    for record in all_results:
-        assert 'number_of_pages' in record
-        assert record['number_of_pages'] == number_of_pages
+    assert 'number_of_pages' in generated_record
+    assert generated_record['number_of_pages'] == expected_number_of_pages
+
+
+@pytest.mark.xfail(reason='outdated field - integration on the 2nd round')
+@pytest.mark.parametrize(
+    'generated_record, expected_keywords',
+    [
+        [
+            get_one_record('world_scientific/sample_ws_record.xml'),
+            [
+                'Perovskite CH$_{3}$NH$_{3}$PbI$_{3}$',
+                'solar cell',
+                'lithium',
+            ],
+        ],
+    ],
+    ids=[
+        'smoke',
+    ]
+)
+def test_free_keywords(generated_record, expected_keywords):
+    """Test extracting free_keywords"""
+    assert 'free_keywords' in generated_record
+    for keyword in generated_record['free_keywords']:
+        assert keyword["source"] == "author"
+        assert keyword["value"] in expected_keywords
+        expected_keywords.remove(keyword['value'])
 
 
 @pytest.mark.parametrize(
-    'all_results',
-    ['world_scientific/sample_ws_record.xml'],
-    indirect=True
+    'generated_record, expected_license',
+    [
+        [
+            get_one_record('world_scientific/sample_ws_record.xml'),
+            [{
+                'license': 'CC-BY-4.0',
+                'url': 'https://creativecommons.org/licenses/by/4.0',
+            }],
+        ],
+    ],
+    ids=[
+        'smoke',
+    ]
 )
-def test_license(all_results):
+def test_license(generated_record, expected_license):
     """Test extracting license information."""
-    expected_license = [{
-        'license': 'CC-BY-4.0',
-        'url': 'https://creativecommons.org/licenses/by/4.0',
-    }]
-    results = list(all_results)
-
-    assert results
-    for record in all_results:
-        assert record['license'] == expected_license
+    assert 'license' in generated_record
+    assert generated_record['license'] == expected_license
 
 
 @pytest.mark.parametrize(
-    'all_results',
-    ['world_scientific/sample_ws_record.xml'],
-    indirect=True
+    'generated_record, expected_dois',
+    [
+        [
+            get_one_record('world_scientific/sample_ws_record.xml'),
+            [{
+                'source': 'hepcrawl',
+                'value': '10.1142/S1793292014400013',
+            }],
+        ],
+    ],
+    ids=[
+        'smoke',
+    ]
 )
-def test_dois(all_results):
+def test_dois(generated_record, expected_dois):
     """Test extracting dois."""
-    dois = "10.1142/S1793292014400013"
-    for record in all_results:
-        assert 'dois' in record
-        assert record['dois'][0]['value'] == dois
+    assert 'dois' in generated_record
+    assert generated_record['dois'] == expected_dois
+
+
+@pytest.mark.xfail(reason='outdated field - integration on the 2nd round')
+@pytest.mark.parametrize(
+    'generated_record, expected_collections',
+    [
+        [
+            get_one_record('world_scientific/sample_ws_record.xml'),
+            [
+                'HEP',
+                'Published',
+            ],
+        ],
+    ],
+    ids=[
+        'smoke',
+    ]
+)
+def test_collections(generated_record, expected_collections):
+    """Test extracting collections."""
+    assert 'collections' in generated_record
+    for coll in expected_collections:
+        assert {"primary": coll} in generated_record['collections']
 
 
 @pytest.mark.parametrize(
-    'all_results',
-    ['world_scientific/sample_ws_record.xml'],
-    indirect=True
+    'generated_record, expected_collaboration',
+    [
+        [
+            get_one_record('world_scientific/sample_ws_record.xml'),
+            [{
+                "value": "Belle Collaboration"
+            }],
+        ],
+    ],
+    ids=[
+        'smoke',
+    ]
 )
-def test_collaborations(all_results):
+def test_collaborations(generated_record, expected_collaboration):
     """Test extracting collaboration."""
-    collaborations = [{"value": "Belle Collaboration"}]
-    for record in all_results:
-        assert 'collaborations' in record
-        assert record['collaborations'] == collaborations
+    assert 'collaborations' in generated_record
+    assert generated_record['collaborations'] == expected_collaboration
 
 
 @pytest.mark.parametrize(
-    'all_results',
-    ['world_scientific/sample_ws_record.xml'],
-    indirect=True
+    'generated_record, expected_publication_info',
+    [
+        [
+            get_one_record('world_scientific/sample_ws_record.xml'),
+            [{
+                'journal_title': 'NANO',
+                'year': 2014,
+                'artid': '1440001',
+                'journal_volume': '9',
+                'journal_issue': '05',
+            }],
+        ],
+    ],
+    ids=[
+        'smoke',
+    ]
 )
-def test_publication_info(all_results):
+def test_publication_info(generated_record, expected_publication_info):
     """Test extracting dois."""
-    journal_title = "NANO"
-    journal_year = 2014
-    journal_artid = "1440001"
-    journal_volume = "9"
-    journal_issue = "05"
-    for record in all_results:
-        assert 'journal_title' in record['publication_info'][0]
-        assert record['publication_info'][0]['journal_title'] == journal_title
-        assert 'year' in record['publication_info'][0]
-        assert record['publication_info'][0]['year'] == journal_year
-        assert 'artid' in record['publication_info'][0]
-        assert record['publication_info'][0]['artid'] == journal_artid
-        assert 'journal_volume' in record['publication_info'][0]
-        assert record['publication_info'][0]['journal_volume'] == journal_volume
-        assert 'journal_issue' in record['publication_info'][0]
-        assert record['publication_info'][0]['journal_issue'] == journal_issue
+    assert 'publication_info' in generated_record
+    assert generated_record['publication_info'] == expected_publication_info
 
 
 @pytest.mark.parametrize(
-    'all_results',
-    ['world_scientific/sample_ws_record.xml'],
-    indirect=True
+    'generated_record, expected_authors',
+    [
+        [
+            get_one_record('world_scientific/sample_ws_record.xml'),
+            {
+                'authors': ["BI, DONGQIN", "BOSCHLOO, GERRIT", "HAGFELDT, ANDERS"],
+                'affiliation': (
+                    'Department of Chemistry-Angstrom Laboratory, Uppsala University, Box 532, SE 751 20 Uppsala, Sweden'
+                ),
+                'xref_affiliation': (
+                    'Physics Department, Brookhaven National Laboratory, Upton, NY 11973, USA'
+                ),
+            },
+        ],
+    ],
+    ids=[
+        'smoke',
+    ]
 )
-def test_authors(all_results):
+def test_authors(generated_record, expected_authors):
     """Test authors."""
-    authors = ["BI, DONGQIN", "BOSCHLOO, GERRIT", "HAGFELDT, ANDERS"]
-    affiliation = "Department of Chemistry-Angstrom Laboratory, Uppsala University, Box 532, SE 751 20 Uppsala, Sweden"
-    xref_affiliation = "Physics Department, Brookhaven National Laboratory, Upton, NY 11973, USA"
-    for record in all_results:
-        assert 'authors' in record
-        assert len(record['authors']) == 3
+    assert 'authors' in generated_record
+    assert len(generated_record['authors']) == 3
 
-        # here we are making sure order is kept
-        for index, name in enumerate(authors):
-            assert record['authors'][index]['full_name'] == name
-            assert affiliation in [
-                aff['value'] for aff in record['authors'][index]['affiliations']
+    # here we are making sure order is kept
+    for index, name in enumerate(expected_authors['authors']):
+            assert generated_record['authors'][index]['full_name'] == name
+            assert expected_authors['affiliation'] in [
+                aff['value'] for aff in generated_record['authors'][index]['affiliations']
             ]
             if index == 1:
-                assert xref_affiliation in [
-                    aff['value'] for aff in record['authors'][index]['affiliations']
+                assert expected_authors['xref_affiliation'] in [
+                    aff['value'] for aff in generated_record['authors'][index]['affiliations']
                 ]
 
 
 @pytest.mark.parametrize(
-    'all_results',
-    ['world_scientific/sample_ws_record.xml'],
-    indirect=True
+    'generated_record, expected_copyright',
+    [
+        [
+            get_one_record('world_scientific/sample_ws_record.xml'),
+            [{
+                'holder': 'World Scientific Publishing Company',
+                'url': 'article',
+            }],
+        ],
+    ],
+    ids=[
+        'smoke',
+    ]
 )
-def test_copyrights(all_results):
+def test_copyrights(generated_record, expected_copyright):
     """Test extracting copyright."""
-    copyright_holder = "World Scientific Publishing Company"
-    copyright_url = "article"
-    for record in all_results:
-        assert 'holder' in record['copyright'][0]
-        assert record['copyright'][0]['holder'] == copyright_holder
-        assert 'url' in record['copyright'][0]
-        assert record['copyright'][0]['url'] == copyright_url
+    assert 'copyright' in generated_record
+    assert generated_record['copyright'] == expected_copyright
 
 
 @pytest.mark.parametrize(
-    'all_results',
-    ['world_scientific/sample_ws_record.xml'],
-    indirect=True
+    'generated_record, expected_citeable',
+    [
+        [
+            get_one_record('world_scientific/sample_ws_record.xml'),
+            True,
+        ],
+    ],
+    ids=[
+        'smoke',
+    ]
 )
-def test_citeable(all_results):
+def test_citeable(generated_record, expected_citeable):
     """Test extracting citeable."""
-    citeable = True
-    for record in all_results:
-        assert 'citeable' in record
-        assert record['citeable'] == citeable
+    assert 'citeable' in generated_record
+    assert generated_record['citeable'] == expected_citeable
 
 
 @pytest.mark.parametrize(
-    'all_results',
-    ['world_scientific/sample_ws_record.xml'],
-    indirect=True
+    'generated_record, expected_document_type',
+    [
+        [
+            get_one_record('world_scientific/sample_ws_record.xml'),
+            [
+                'article',
+            ],
+        ],
+    ],
+    ids=[
+        'smoke',
+    ]
 )
-def test_document_type(all_results):
+def test_document_type(generated_record, expected_document_type):
     """Test extracting document_type."""
-    document_type = 'article'
-    for record in all_results:
-        assert 'document_type' in record
-        assert record['document_type'][0] == document_type
+    assert 'document_type' in generated_record
+    assert generated_record['document_type'] == expected_document_type
 
 
 @pytest.mark.parametrize(
-    'all_results',
-    ['world_scientific/sample_ws_record.xml'],
-    indirect=True
+    'generated_record, expected_refereed',
+    [
+        [
+            get_one_record('world_scientific/sample_ws_record.xml'),
+            True,
+        ],
+    ],
+    ids=[
+        'smoke',
+    ]
 )
-def test_refereed(all_results):
+def test_refereed(generated_record, expected_refereed):
     """Test extracting refereed."""
-    refereed = True
-    for record in all_results:
-        assert 'refereed' in record
-        assert record['refereed'] == refereed
+    assert 'refereed' in generated_record
+    assert generated_record['refereed'] == expected_refereed
 
 
 @pytest.mark.parametrize(
-    'all_results',
-    ['world_scientific/wsp_record.xml'],
-    indirect=True
+    'generated_record',
+    [
+        get_one_record('world_scientific/wsp_record.xml'),
+    ],
+    ids=[
+        'smoke',
+    ]
 )
-def test_pipeline_record(one_result):
+def test_pipeline_record(generated_record):
     expected = {
         'abstracts': [
             {
@@ -344,4 +468,4 @@ def test_pipeline_record(one_result):
         ],
     }
 
-    assert override_generated_fields(one_result) == expected
+    assert override_generated_fields(generated_record) == expected


### PR DESCRIPTION
* Updated WSP unit tests, using the full pipeline output to the tests.
* Removed WSP unit tests checking wrong fields.
* Added WSP unit tests for not tested fields.
* Added fixture that returns record created by the pipeline output. 

Closes #111 

Signed-off-by: Spiros Delviniotis <spyridon.delviniotis@cern.ch>