### PR TITLE
global: source should always be spider name

### DIFF
--- a/hepcrawl/crawler2hep.py
+++ b/hepcrawl/crawler2hep.py
@@ -27,7 +27,9 @@ def crawler2hep(crawler_record):
             if affilation.get('value')
         ]
 
-    builder = LiteratureBuilder('hepcrawl')
+    builder = LiteratureBuilder(
+        source=crawler_record['acquisition_source']['source']
+    )
 
     for author in crawler_record.get('authors', []):
         builder.add_author(builder.make_author(
@@ -93,10 +95,10 @@ def crawler2hep(crawler_record):
 
     acquisition_source = crawler_record.get('acquisition_source', {})
     builder.add_acquisition_source(
-        method='hepcrawl',
-        date=acquisition_source.get('date'),
-        source=acquisition_source.get('source'),
-        submission_number=acquisition_source.get('submission_number')
+        method=acquisition_source['method'],
+        date=acquisition_source['date'],
+        source=acquisition_source['source'],
+        submission_number=acquisition_source['submission_number'],
     )
 
     try:

--- a/hepcrawl/pipelines.py
+++ b/hepcrawl/pipelines.py
@@ -56,12 +56,10 @@ class InspireAPIPushPipeline(object):
         if 'related_article_doi' in item:
             item['dois'] += item.pop('related_article_doi', [])
 
-        source = item.pop('source', spider.name)
+        source = spider.name
         item['acquisition_source'] = {
             'source': source,
-            # NOTE: Keeps method same as source to conform with INSPIRE
-            # submissions which add `submissions` to this field.
-            'method': source,
+            'method': 'hepcrawl',
             'date': datetime.datetime.now().isoformat(),
             'submission_number': os.environ.get('SCRAPY_JOB', ''),
         }

--- a/hepcrawl/spiders/arxiv_spider.py
+++ b/hepcrawl/spiders/arxiv_spider.py
@@ -201,7 +201,7 @@ class ArxivSpider(XMLFeedSpider):
         if report_numbers:
             return [
                 {
-                    'source': '',
+                    'source': self.name,
                     'value': rn.strip(),
                 } for rn in report_numbers.split(',')
             ]

--- a/tests/functional/wsp/fixtures/wsp_smoke_records.json
+++ b/tests/functional/wsp/fixtures/wsp_smoke_records.json
@@ -22,7 +22,7 @@
 		"title": "Article-title\u2019s"
 	}],
 	"dois": [{
-		"source": "hepcrawl",
+		"source": "WSP",
 		"value": "10.1142/S0219025717500060"
 	}],
 	"publication_info": [{
@@ -70,7 +70,7 @@
 		"title": "Article-title L\u00e9vy char"
 	}],
 	"dois": [{
-		"source": "hepcrawl",
+		"source": "WSP",
 		"value": "10.1142/S0219025717500023"
 	}],
 	"publication_info": [{

--- a/tests/unit/test_arxiv_all.py
+++ b/tests/unit/test_arxiv_all.py
@@ -228,14 +228,14 @@ def test_repno(many_results):
         None,
         [{
             'value': 'YITP-2016-26',
-            'source': 'hepcrawl',
+            'source': 'arXiv',
         }],
         None,
         None,
         None,
         [
-            {'source': 'hepcrawl', 'value': u'DES 2016-0158'},
-            {'source': 'hepcrawl', 'value': u'FERMILAB PUB-16-231-AE'}
+            {'source': 'arXiv', 'value': u'DES 2016-0158'},
+            {'source': 'arXiv', 'value': u'FERMILAB PUB-16-231-AE'}
         ],
         None,
         None,

--- a/tests/unit/test_arxiv_single.py
+++ b/tests/unit/test_arxiv_single.py
@@ -138,7 +138,7 @@ def test_dois(results):
     """Test extracting dois."""
     expected_dois = [
         {
-            'source': 'hepcrawl',
+            'source': 'arXiv',
             'value': '10.1103/PhysRevD.93.016005',
         }
     ]
@@ -164,7 +164,7 @@ def test_repno(results):
     """Test extracting repor numbers."""
     expected_repno = [{
         'value': 'YITP-2016-26',
-        'source': 'hepcrawl',
+        'source': 'arXiv',
     }]
     for record in results:
         assert 'report_numbers' in record

--- a/tests/unit/test_pipelines.py
+++ b/tests/unit/test_pipelines.py
@@ -27,7 +27,7 @@ from hepcrawl.testlib.fixtures import fake_response_from_file
 @pytest.fixture
 def spider():
     mock_spider = mock.create_autospec(Spider)
-    mock_spider.name = 'TestSpider'
+    mock_spider.name = 'arXiv'
     mock_spider.state = {}
     return mock_spider
 

--- a/tests/unit/test_pos.py
+++ b/tests/unit/test_pos.py
@@ -59,7 +59,7 @@ def test_titles(record):
     """Test extracting title."""
     expected_titles = [
         {
-            'source': 'Sissa Medialab',
+            'source': 'PoS',
             'title': 'Heavy Flavour Physics Review',
         }
     ]

--- a/tests/unit/test_world_scientific.py
+++ b/tests/unit/test_world_scientific.py
@@ -200,7 +200,7 @@ def test_license(generated_record, expected_license):
         [
             get_one_record('world_scientific/sample_ws_record.xml'),
             [{
-                'source': 'hepcrawl',
+                'source': 'WSP',
                 'value': '10.1142/S1793292014400013',
             }],
         ],
@@ -441,7 +441,7 @@ def test_pipeline_record(generated_record):
         ],
         'dois': [
             {
-                'source': 'hepcrawl', 'value': u'10.1142/S0219025717500060',
+                'source': 'WSP', 'value': u'10.1142/S0219025717500060',
             },
         ],
         'imprints': [


### PR DESCRIPTION
* Re-factored tests in order to catch similar bugs at the future. Tests re-factored:
         1. `arxiv` unit tests.
         2. `wsp` functional and unit tests.
         3. `pos` unit tests.
         4. `pipeline` unit tests.
* Fix: populate `acquisition_source.source` with `spider.name`
       and `acquisition_source.method` with `hepcrawl`.
* Fix: construct `LiteratureBuilder` with `acquisition_source.source` instead of passing `hepcrawl`.

Closes #130 

Signed-off-by: Spiros Delviniotis <spirosdelviniotis@gmail.com>
