### PR TITLE
global: upgrade to the latest `inspire-schemas` version `34.3`

### DIFF
--- a/hepcrawl/spiders/wsp_spider.py
+++ b/hepcrawl/spiders/wsp_spider.py
@@ -190,7 +190,7 @@ class WorldScientificSpider(Jats, XMLFeedSpider):
         record.add_xpath('copyright_holder', '//copyright-holder/text()')
         record.add_xpath('copyright_year', '//copyright-year/text()')
         record.add_xpath('copyright_statement', '//copyright-statement/text()')
-        record.add_value('copyright_material', 'Article')
+        record.add_value('copyright_material', 'publication')
 
         license = get_license(
             license_url=node.xpath(

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ readme = open('README.rst').read()
 
 install_requires = [
     'autosemver~=0.2',
-    'inspire-schemas~=31.0',
+    'inspire-schemas~=34.3',
     'Scrapy>=1.1.0',
     # TODO: unpin once they support wheel building again
     'scrapyd==1.1.0',

--- a/tests/functional/wsp/fixtures/wsp_smoke_records.json
+++ b/tests/functional/wsp/fixtures/wsp_smoke_records.json
@@ -7,7 +7,7 @@
 		"datetime": "2017-04-21T14:56:10.981309"
 	},
 	"copyright": [{
-		"url": "article",
+		"material": "publication",
 		"holder": "Copyright Holder"
 	}],
 	"number_of_pages": 6,
@@ -38,7 +38,7 @@
 		"value": "Abstract L\u00e9vy bla-bla bla blaaa blaa bla blaaa blaa, bla blaaa blaa. Bla blaaa blaa."
 	}],
 	"imprints": [{
-		"date": "2017-03-30T00:00:00"
+		"date": "2017-03-30"
 	}],
 	"citeable": true
 }, {
@@ -50,7 +50,7 @@
 		"datetime": "2017-04-21T14:56:11.026428"
 	},
 	"copyright": [{
-		"url": "article",
+		"material": "publication",
 		"holder": "Copyright Holder"
 	}],
 	"number_of_pages": 21,
@@ -86,7 +86,7 @@
 		"value": "Abstract L\u00e9vy bla-bla bla blaaa blaa bla blaaa blaa, bla blaaa blaa. Bla blaaa blaa <math><msup><mrow><mi>L</mi></mrow><mrow><mn>2</mn></mrow></msup></math>-bla blaaa blaa, Bla\u2019s bla, bla blaaa blaa."
 	}],
 	"imprints": [{
-		"date": "2017-03-30T00:00:00"
+		"date": "2017-03-30"
 	}],
 	"citeable": true
 }]

--- a/tests/unit/test_world_scientific.py
+++ b/tests/unit/test_world_scientific.py
@@ -115,7 +115,7 @@ def test_title(generated_record, expected_title):
         [
             get_one_record('world_scientific/sample_ws_record.xml'),
             [{
-                'date': '2014-06-05T00:00:00',
+                'date': '2014-06-05',
             }],
         ],
     ],
@@ -326,7 +326,7 @@ def test_authors(generated_record, expected_authors):
             get_one_record('world_scientific/sample_ws_record.xml'),
             [{
                 'holder': 'World Scientific Publishing Company',
-                'url': 'article',
+                'material': 'publication',
             }],
         ],
     ],
@@ -433,7 +433,7 @@ def test_pipeline_record(generated_record):
         'copyright': [
             {
                 'holder': u'Copyright Holder',
-                'url': 'article',
+                'material': 'publication',
             },
         ],
         'document_type': [
@@ -446,7 +446,7 @@ def test_pipeline_record(generated_record):
         ],
         'imprints': [
             {
-                'date': '2017-03-30T00:00:00',
+                'date': '2017-03-30',
             },
         ],
         'number_of_pages': 6,


### PR DESCRIPTION
* Adds: upgrade `inspire-schemas` to latest version `34.3`.
* Adds: support for the latest `inspire-schemas` version `34.3`.
* Adapt unit tests to latest `inspire-schemas` version `34.3`.
* Adapt functional tests to latest `inspire-schemas` version `34.3`.

Closes #139 
Relates to #128 

**Re-based on top of #142**

Signed-off-by: Spiros Delviniotis <spirosdelviniotis@gmail.com>