### PR TITLE
global: support `material` field for `dois`

### DIFF
--- a/hepcrawl/crawler2hep.py
+++ b/hepcrawl/crawler2hep.py
@@ -57,7 +57,8 @@ def crawler2hep(crawler_record):
 
     for doi in crawler_record.get('dois', []):
         builder.add_doi(
-            doi=doi.get('value')
+            doi=doi.get('value'),
+            material=doi.get('material'),
         )
 
     for public_note in crawler_record.get('public_notes', []):

--- a/hepcrawl/loaders.py
+++ b/hepcrawl/loaders.py
@@ -152,7 +152,6 @@ class HEPLoader(ItemLoader):
 
     classification_numbers_out = ClassificationNumbers()
 
-    dois_out = ListToValueDict()
     related_article_doi_out = ListToValueDict()
 
     thesis_supervisor_in = MapCompose(
@@ -164,6 +163,46 @@ class HEPLoader(ItemLoader):
         canonicalize_url,
     )
     urls_out = ListToValueDict()
+
+    def add_dois(self, dois_values=None, material=None):
+        """Adds `dois` field to `self`.
+
+        Args:
+            dois_values (list):The `dois` represented by a list of strings.
+            material (str):The `material` of the dois.
+
+        Examples:
+            Using `dois`::
+
+                >>> from hepcrawl.items import HEPRecord
+                >>> record = HEPLoader(item=HEPRecord(), selector=selector)
+                >>> record.add_dois(dois=dois_list_str)
+
+            Using `dois` and `material`::
+
+                >>> from hepcrawl.items import HEPRecord
+                >>> record = HEPLoader(item=HEPRecord(), selector=selector)
+                >>> record.add_dois(dois=dois_list_str, material='preprint')
+        """
+        def _build_doi(doi_value, material):
+            doi = {
+                'value': doi_value
+            }
+            if material:
+                doi['material'] = material
+
+            return doi
+
+        if not dois_values:
+            return
+
+        dois = [
+            _build_doi(doi_value, material)
+            for doi_value in dois_values
+        ]
+
+        self.add_value('dois', dois)
+
 
 # FIXME: if possible everything with open access should get a FFT
 # FIXME: check that every record has collection HEP

--- a/hepcrawl/spiders/aps_spider.py
+++ b/hepcrawl/spiders/aps_spider.py
@@ -76,7 +76,8 @@ class APSSpider(Spider):
         for article in aps_response['data']:
             record = HEPLoader(item=HEPRecord(), response=response)
 
-            record.add_value('dois', get_nested(article, 'identifiers', 'doi'))
+            dois = [get_nested(article, 'identifiers', 'doi')]
+            record.add_dois(dois_values=dois)
             record.add_value('page_nr', str(article.get('numPages', '')))
 
             record.add_value('abstract', get_nested(article, 'abstract', 'value'))

--- a/hepcrawl/spiders/arxiv_spider.py
+++ b/hepcrawl/spiders/arxiv_spider.py
@@ -60,7 +60,10 @@ class ArxivSpider(XMLFeedSpider):
         record.add_xpath('title', './/title/text()')
         record.add_xpath('abstract', './/abstract/text()')
         record.add_xpath('preprint_date', './/created/text()')
-        record.add_xpath('dois', './/doi//text()')
+        record.add_dois(
+            dois_values=self._get_dois(node=node),
+            material='publication',
+        )
         record.add_xpath('pubinfo_freetext', './/journal-ref//text()')
         record.add_value('source', 'arXiv')
 
@@ -218,3 +221,6 @@ class ArxivSpider(XMLFeedSpider):
             'institute': 'arXiv',
             'value': node.xpath('.//identifier//text()').extract_first()
         }
+
+    def _get_dois(self, node):
+        return node.xpath('.//doi//text()').extract()

--- a/hepcrawl/spiders/edp_spider.py
+++ b/hepcrawl/spiders/edp_spider.py
@@ -279,7 +279,7 @@ class EDPSpider(Jats, XMLFeedSpider):
         article_type = response.meta.get("article_type")
         record = HEPLoader(item=HEPRecord(), selector=node, response=response)
 
-        record.add_value('dois', response.meta.get("dois"))
+        record.add_dois(dois_values=response.meta.get("dois"))
         record.add_xpath('abstract', './/Abstract')
         record.add_xpath('title', './/ArticleTitle/Title')
         record.add_xpath('subtitle', './/ArticleTitle/Subtitle')
@@ -332,7 +332,7 @@ class EDPSpider(Jats, XMLFeedSpider):
                              './/related-article[@ext-link-type="doi"]/@href')
             record.add_value('journal_doctype', article_type)
 
-        record.add_value('dois', response.meta.get("dois"))
+        record.add_dois(dois_values=response.meta.get("dois"))
         record.add_xpath('page_nr', ".//counts/page-count/@count")
         record.add_xpath('abstract', './/abstract[1]')
         record.add_xpath('title', './/article-title/text()')

--- a/hepcrawl/spiders/elsevier_spider.py
+++ b/hepcrawl/spiders/elsevier_spider.py
@@ -1018,7 +1018,7 @@ class ElsevierSpider(XMLFeedSpider):
             record.add_value('journal_issue', info.get("issue"))
             record.add_value('journal_volume', info.get("volume"))
             record.add_value('journal_issn', info.get("issn"))
-            record.add_value("dois", info.get("dois"))
+            record.add_dois(dois_values=info.get("dois"))
             record.add_value('journal_doctype', doctype)
             record.add_value('journal_fpage', info.get("fpage"))
             record.add_value('journal_lpage', info.get("lpage"))

--- a/hepcrawl/spiders/hindawi_spider.py
+++ b/hepcrawl/spiders/hindawi_spider.py
@@ -174,8 +174,11 @@ class HindawiSpider(XMLFeedSpider):
                          "./datafield[@tag='260']/subfield[@code='c']/text()")
         record.add_xpath('page_nr',
                          "./datafield[@tag='300']/subfield[@code='a']/text()")
-        record.add_xpath('dois',
-                         "./datafield[@tag='024'][subfield[@code='2'][contains(text(), 'DOI')]]/subfield[@code='a']/text()")
+        dois = node.xpath(
+            "./datafield[@tag='024'][subfield[@code='2'][contains(text(), 'DOI')]]"
+            "/subfield[@code='a']/text()"
+        ).extract()
+        record.add_dois(dois_values=dois)
         record.add_xpath('journal_title',
                          "./datafield[@tag='773']/subfield[@code='p']/text()")
         record.add_xpath('journal_volume',

--- a/hepcrawl/spiders/iop_spider.py
+++ b/hepcrawl/spiders/iop_spider.py
@@ -185,7 +185,7 @@ class IOPSpider(XMLFeedSpider, NLM):
         record.add_value("journal_issue", issue)
         record.add_value("journal_volume", volume)
         record.add_xpath("journal_issn", ".//Journal/Issn/text()")
-        record.add_value("dois", self.get_dois(node))
+        record.add_dois(dois_values=self.get_dois(node))
 
         journal_year = node.xpath(".//Journal/PubDate/Year/text()").extract()
         if journal_year:

--- a/hepcrawl/spiders/phil_spider.py
+++ b/hepcrawl/spiders/phil_spider.py
@@ -139,7 +139,7 @@ class PhilSpider(CrawlSpider):
 
         record.add_value('title', jsonrecord['title'])
         record.add_value('abstract', jsonrecord['abstract'])
-        record.add_value('dois', jsonrecord['doi'])
+        record.add_dois(dois_values=jsonrecord['doi'])
         record.add_value('page_nr', jsonrecord['pages'])
         record.add_value('authors', self.get_authors(jsonrecord['authors']))
         record.add_value('file_urls', response.meta.get("direct_links"))

--- a/hepcrawl/spiders/wsp_spider.py
+++ b/hepcrawl/spiders/wsp_spider.py
@@ -155,7 +155,9 @@ class WorldScientificSpider(Jats, XMLFeedSpider):
                             'addendum']:
             record.add_xpath('related_article_doi', "//related-article[@ext-link-type='doi']/@href")
             record.add_value('journal_doctype', article_type)
-        record.add_xpath('dois', "//article-id[@pub-id-type='doi']/text()")
+
+        dois = node.xpath("//article-id[@pub-id-type='doi']/text()").extract()
+        record.add_dois(dois_values=dois)
         record.add_xpath('page_nr', "//counts/page-count/@count")
 
         record.add_xpath('abstract', '//abstract[1]')

--- a/tests/functional/arxiv/fixtures/arxiv_smoke_record.json
+++ b/tests/functional/arxiv/fixtures/arxiv_smoke_record.json
@@ -35,6 +35,13 @@
     "document_type": [
       "conference paper"
     ],
+    "dois": [
+      {
+        "material": "publication",
+        "source": "arXiv",
+        "value": "10.1103/PhysRevD.93.016005"
+      }
+    ],
     "license": [
       {
         "license": "arXiv-1.0",

--- a/tests/functional/arxiv/fixtures/oai_harvested/arxiv_smoke_record.xml
+++ b/tests/functional/arxiv/fixtures/oai_harvested/arxiv_smoke_record.xml
@@ -14,7 +14,7 @@
  <id>1512.07978</id><created>2015-12-25</created>
  <authors><author>
  <keyname>Teresa Maria Montaruli for the IceCube Collaboration</keyname></author></authors><title>Neutrino Physics and Astrophysics with IceCube</title><categories>astro-ph.HE</categories><comments>Proc. of CRIS2015, Gallipoli, Italy, 8 pages, 17 figures, to appear
-  in Elsevier in Nuclear and Particle Physics Proceedings (2016)</comments><license>http://arxiv.org/licenses/nonexclusive-distrib/1.0/</license><abstract>  In this contribution we summarize the selected highlights of IceCube in the
+  in Elsevier in Nuclear and Particle Physics Proceedings (2016)</comments><doi>10.1103/PhysRevD.93.016005</doi><license>http://arxiv.org/licenses/nonexclusive-distrib/1.0/</license><abstract>  In this contribution we summarize the selected highlights of IceCube in the
 domain of high-energy astrophysics and particle physics. We discuss the
 highest-energy neutrino detection and its interpretation after 4 years of data.
 The significance is such that the discovery of a non terrestrial component can

--- a/tests/unit/test_arxiv_single.py
+++ b/tests/unit/test_arxiv_single.py
@@ -140,6 +140,7 @@ def test_dois(results):
         {
             'source': 'arXiv',
             'value': '10.1103/PhysRevD.93.016005',
+            'material': 'publication',
         }
     ]
     for record in results:


### PR DESCRIPTION
* Adds: `HEPLoader.get_dois` method that populates `dois` field.
	         Previously field `material` inside `dois` was missing.
* Adds: adapt `HEPLoader.get_dois` to related spiders.
* Adds: support for `material` field in `dois`.
* Adds: missing `dois` testing field from `arxiv` functional tests.

Addresses #128 

Signed-off-by: Spiros Delviniotis <spirosdelviniotis@gmail.com>