### PR TITLE
global: pin setuptools to `<36`

### DIFF
--- a/tests/docker_entrypoint.sh
+++ b/tests/docker_entrypoint.sh
@@ -45,7 +45,7 @@ prepare_venv() {
     virtualenv "$VENV_PATH"
     source "$VENV_PATH"/bin/activate
     pip install --upgrade pip
-    pip install --upgrade setuptools wheel
+    pip install --upgrade 'setuptools<36' wheel
 }
 
 


### PR DESCRIPTION
## Base PR for current PRs

* Pin `setuptools` to version `<36` due to an issue for `six` module.

Signed-off-by: Spiros Delviniotis <spirosdelviniotis@gmail.com>