### PR TITLE
global: support `material` field for `license`

### DIFF
--- a/hepcrawl/crawler2hep.py
+++ b/hepcrawl/crawler2hep.py
@@ -70,7 +70,8 @@ def crawler2hep(crawler_record):
     for license in crawler_record.get('license', []):
         builder.add_license(
             url=license.get('url'),
-            license=license.get('license')
+            license=license.get('license'),
+            material=license.get('material'),
         )
 
     for collaboration in crawler_record.get('collaborations', []):

--- a/hepcrawl/items.py
+++ b/hepcrawl/items.py
@@ -174,8 +174,18 @@ class HEPRecord(scrapy.Item):
     """Page number as string. E.g. ``2``."""
 
     license = scrapy.Field()
-    license_url = scrapy.Field()
-    license_type = scrapy.Field()  # E.g. "open-access"
+    """License
+
+    Example:
+        ::
+            [
+                {
+                    'license': license_str,
+                    'url': license_url,
+                    'material': preprint
+                }
+            ]
+    """
 
     copyright = scrapy.Field()
     """Final structure for copyright information."""

--- a/hepcrawl/spiders/aps_spider.py
+++ b/hepcrawl/spiders/aps_spider.py
@@ -20,7 +20,7 @@ from scrapy import Request, Spider
 
 from ..items import HEPRecord
 from ..loaders import HEPLoader
-from ..utils import get_license, get_nested, build_dict
+from ..utils import get_licenses, get_nested, build_dict
 
 
 class APSSpider(Spider):
@@ -104,7 +104,7 @@ class APSSpider(Spider):
             record.add_value('copyright_statement', get_nested(article, 'rights', 'rightsStatement'))
             record.add_value('copyright_material', 'Article')
 
-            license = get_license(
+            license = get_licenses(
                 license_url=get_nested(article, 'rights', 'licenses')[0]['url']
             )
             record.add_value('license', license)

--- a/hepcrawl/spiders/arxiv_spider.py
+++ b/hepcrawl/spiders/arxiv_spider.py
@@ -100,7 +100,8 @@ class ArxivSpider(XMLFeedSpider):
         )
 
         license = get_licenses(
-            license_url=node.xpath('.//license//text()').extract_first()
+            license_url=node.xpath('.//license//text()').extract_first(),
+            license_material='preprint',
         )
         record.add_value('license', license)
 

--- a/hepcrawl/spiders/arxiv_spider.py
+++ b/hepcrawl/spiders/arxiv_spider.py
@@ -17,7 +17,7 @@ from scrapy import Request, Selector
 from scrapy.spiders import XMLFeedSpider
 
 from ..mappings import CONFERENCE_WORDS, THESIS_WORDS
-from ..utils import coll_cleanforthe, get_license, split_fullname
+from ..utils import coll_cleanforthe, get_licenses, split_fullname
 from ..items import HEPRecord
 from ..loaders import HEPLoader
 
@@ -99,7 +99,7 @@ class ArxivSpider(XMLFeedSpider):
             self._get_ext_systems_number(node)
         )
 
-        license = get_license(
+        license = get_licenses(
             license_url=node.xpath('.//license//text()').extract_first()
         )
         record.add_value('license', license)

--- a/hepcrawl/spiders/edp_spider.py
+++ b/hepcrawl/spiders/edp_spider.py
@@ -27,7 +27,7 @@ from ..utils import (
     ftp_connection_info,
     get_first,
     get_journal_and_section,
-    get_license,
+    get_licenses,
     get_node,
     parse_domain,
 )
@@ -364,7 +364,7 @@ class EDPSpider(Jats, XMLFeedSpider):
                          './/copyright-statement/text()')
         record.add_value('copyright_material', 'Article')
 
-        license = get_license(
+        license = get_licenses(
             license_url=node.xpath(
                 './/license/license-p/ext-link/@href'
             ).extract_first()

--- a/hepcrawl/spiders/elsevier_spider.py
+++ b/hepcrawl/spiders/elsevier_spider.py
@@ -27,7 +27,7 @@ from ..items import HEPRecord
 from ..loaders import HEPLoader
 from ..utils import (
     get_first,
-    get_license,
+    get_licenses,
     has_numbers,
     range_as_string,
     unzip_xml_files,
@@ -999,7 +999,7 @@ class ElsevierSpider(XMLFeedSpider):
             if requests.head(sd_url).status_code == 200:  # Test if valid url
                 record.add_value("urls", sd_url)
 
-        license = get_license(
+        license = get_licenses(
             license_url=node.xpath(
                 ".//oa:userLicense/text()"
             ).extract_first(),

--- a/hepcrawl/spiders/hindawi_spider.py
+++ b/hepcrawl/spiders/hindawi_spider.py
@@ -16,7 +16,7 @@ from scrapy.spiders import XMLFeedSpider
 
 from ..items import HEPRecord
 from ..loaders import HEPLoader
-from ..utils import get_license
+from ..utils import get_licenses
 
 
 class HindawiSpider(XMLFeedSpider):
@@ -200,7 +200,7 @@ class HindawiSpider(XMLFeedSpider):
         record.add_value('copyright_statement', cr_statement)
         record.add_value('copyright_year', cr_year)
 
-        license = get_license(
+        license = get_licenses(
             license_url=node.xpath(
                 "./datafield[@tag='540']/subfield[@code='u']/text()"
             ).extract_first(),

--- a/hepcrawl/spiders/pos_spider.py
+++ b/hepcrawl/spiders/pos_spider.py
@@ -16,7 +16,7 @@ import re
 from scrapy import Request, Selector
 from scrapy.spiders import Spider
 from urlparse import urljoin
-from ..utils import get_license, get_first
+from ..utils import get_licenses, get_first
 from ..dateutils import create_valid_date
 from ..items import HEPRecord
 from ..loaders import HEPLoader
@@ -87,7 +87,7 @@ class POSSpider(Spider):
 
         record.add_value('external_system_numbers', self._get_ext_systems_number(node))
 
-        license = get_license(
+        license = get_licenses(
             license_text=node.xpath(
                 ".//metadata/pex-dc/rights/text()"
             ).extract_first(),

--- a/hepcrawl/spiders/wsp_spider.py
+++ b/hepcrawl/spiders/wsp_spider.py
@@ -24,7 +24,7 @@ from ..utils import (
     ftp_list_files,
     ftp_connection_info,
     local_list_files,
-    get_license,
+    get_licenses,
     unzip_xml_files,
 )
 
@@ -194,7 +194,7 @@ class WorldScientificSpider(Jats, XMLFeedSpider):
         record.add_xpath('copyright_statement', '//copyright-statement/text()')
         record.add_value('copyright_material', 'publication')
 
-        license = get_license(
+        license = get_licenses(
             license_url=node.xpath(
                 '//license/license-p/ext-link/@href').extract_first(),
             license_text=node.xpath(

--- a/hepcrawl/utils.py
+++ b/hepcrawl/utils.py
@@ -261,26 +261,38 @@ def get_journal_and_section(publication):
     return journal_title, section
 
 
-def get_license(license_url='', license_text=''):
+def get_license(
+    license_url='',
+    license_text='',
+    license_material='',
+):
     """Get the license dictionary from the url or the text of the license.
 
     Args:
         license_url(str): Url of the license to generate.
         license_text(str): Text with the description of the license (sometimes is
             all we got...).
+        license_material(str): Material of the license.
 
     Returns:
         list(dict): license object to be added to the generated record, empty list
             if no license could be extracted.
     """
-    license = []
-    if license_url:
+    def _populate_license_material(license):
+        if license_material:
+            license['material'] = license_material
+        return license
+
+    def _get_license():
         license = get_license_by_url(license_url=license_url)
+        if not license:
+            license = get_license_by_text(license_text=license_text)
 
-    if not license and license_text:
-        license = get_license_by_text(license_text=license_text)
+        return license
 
-    return license
+    license = _get_license()
+
+    return [_populate_license_material(license)] if license else []
 
 
 def get_license_by_url(license_url):
@@ -296,7 +308,7 @@ def get_license_by_url(license_url):
                 license_url.strip('/'),
             )
             break
-    return [{'license': license_str, 'url': license_url}]
+    return {'license': license_str, 'url': license_url}
 
 
 def get_license_by_text(license_text):

--- a/hepcrawl/utils.py
+++ b/hepcrawl/utils.py
@@ -261,7 +261,7 @@ def get_journal_and_section(publication):
     return journal_title, section
 
 
-def get_license(
+def get_licenses(
     license_url='',
     license_text='',
     license_material='',
@@ -275,12 +275,13 @@ def get_license(
         license_material(str): Material of the license.
 
     Returns:
-        list(dict): license object to be added to the generated record, empty list
+        list(dict): list of dictionaries that are licenses, empty list
             if no license could be extracted.
     """
     def _populate_license_material(license):
         if license_material:
             license['material'] = license_material
+
         return license
 
     def _get_license():

--- a/tests/functional/arxiv/fixtures/arxiv_smoke_record.json
+++ b/tests/functional/arxiv/fixtures/arxiv_smoke_record.json
@@ -45,6 +45,7 @@
     "license": [
       {
         "license": "arXiv-1.0",
+        "material": "preprint",
         "url": "http://arxiv.org/licenses/nonexclusive-distrib/1.0/"
       }
     ],

--- a/tests/unit/responses/arxiv/sample_arxiv_record10_parsed.json
+++ b/tests/unit/responses/arxiv/sample_arxiv_record10_parsed.json
@@ -8,7 +8,8 @@
             "citeable": true, 
             "license": [
                 {
-                    "url": "http://arxiv.org/licenses/nonexclusive-distrib/1.0/", 
+                    "url": "http://arxiv.org/licenses/nonexclusive-distrib/1.0/",
+                    "material": "preprint",
                     "license": "arXiv-1.0"
                 }
             ], 

--- a/tests/unit/test_arxiv_single.py
+++ b/tests/unit/test_arxiv_single.py
@@ -127,6 +127,7 @@ def test_license(results):
     """Test extracting license information."""
     expected_license = [{
         'license': 'CC-BY-3.0',
+        'material': 'preprint',
         'url': 'https://creativecommons.org/licenses/by/3.0/',
     }]
     for record in results:


### PR DESCRIPTION
* Re-factored `utils.get_license` method.
* Adds: support for `license.material` field.
* Re-factored `utils.get_license` to `utils.get_license_list`.
* Removes: `license_url` unused field for `license` field.
* Removes: `license_type` unused field for `license` field.
* Adds: docstring example for `license` field.
* Adds: support `license.material` field for `arxiv` functional tests.
* Adds: support `license.material` field for `arxiv` unit tests.
* Adds: support `license.material` field for `arxiv` spider.

Addresses #128

Signed-off-by: Spiros Delviniotis <spirosdelviniotis@gmail.com>