### PR TITLE
global: support `material` field for `copyright`

### DIFF
--- a/hepcrawl/items.py
+++ b/hepcrawl/items.py
@@ -183,7 +183,7 @@ class HEPRecord(scrapy.Item):
     copyright_holder = scrapy.Field()
     copyright_year = scrapy.Field()
     copyright_statement = scrapy.Field()
-    copyright_material = scrapy.Field()  # E.g "Article"
+    copyright_material = scrapy.Field()  # E.g "preprint"
 
     journal_title = scrapy.Field()
     journal_volume = scrapy.Field()

--- a/hepcrawl/spiders/arxiv_spider.py
+++ b/hepcrawl/spiders/arxiv_spider.py
@@ -100,6 +100,10 @@ class ArxivSpider(XMLFeedSpider):
             license_url=node.xpath('.//license//text()').extract_first()
         )
         record.add_value('license', license)
+        record.add_value(
+            'copyright_material',
+            'preprint',
+        )
 
         parsed_record = dict(record.load_item())
         return parsed_record

--- a/tests/functional/arxiv/fixtures/arxiv_smoke_record.json
+++ b/tests/functional/arxiv/fixtures/arxiv_smoke_record.json
@@ -32,6 +32,11 @@
         "value": "IceCube"
       }
     ],
+    "copyright": [
+      {
+        "material": "preprint"
+      }
+    ],
     "document_type": [
       "conference paper"
     ],

--- a/tests/unit/responses/arxiv/sample_arxiv_record10_parsed.json
+++ b/tests/unit/responses/arxiv/sample_arxiv_record10_parsed.json
@@ -40,7 +40,12 @@
             ], 
             "document_type": [
                 "thesis"
-            ], 
+            ],
+            "copyright": [
+                {
+                    "material": "preprint"
+                }
+            ],
             "abstracts": [
                 {
                     "source": "arXiv", 


### PR DESCRIPTION
* Adds: support `copyright.material` for `arxiv` functional tests.
* Adds: support `copyright.material` for `pipeline` unit tests
  (pipeline tests are using `arxiv` spider).
* Adds: support `copyright.material` for `arxiv` spider.
* Adds: minor change to comment example in `items.py`

Addresses #128

Signed-off-by: Spiros Delviniotis <spirosdelviniotis@gmail.com>