### PR TITLE
unit tests: mock the connection to external services

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ tests_require = [
     'pytest-cov>=2.1.0',
     'pytest-pep8>=1.0.6',
     'responses>=0.5.0',
+    'requests-mock>=1.3.0',
     'pydocstyle>=1.0.0',
     'PyYAML',
 ]

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import pytest
 
+import requests_mock
 import responses
 
 from scrapy.selector import Selector
@@ -160,7 +161,15 @@ def splash():
     spider._register_namespaces(selector)
     nodes = selector.xpath('.//%s' % spider.itertag)
     splash_response.meta["record"] = nodes[0].extract()
-    return spider.scrape_for_pdf(splash_response)
+
+    with requests_mock.Mocker() as mock:
+        mock.head(
+            'http://www.example.com/bitstream/1885/10005/1/Butt_R.D._2003.pdf',
+            headers={
+                'Content-Type': 'text/html',
+            },
+        )
+        return spider.scrape_for_pdf(splash_response)
 
 
 def test_splash(splash):
@@ -221,7 +230,15 @@ def parsed_node_without_link():
     response = fake_response_from_string(text=body)
     node = get_node(spider, 'OAI-PMH:record', text=body)
     response.meta["record"] = node.extract()
-    return spider.parse_node(response, node)
+
+    with requests_mock.Mocker() as mock:
+        mock.head(
+            'http://www.example.com',
+            headers={
+                'Content-Type': 'text/html',
+            },
+        )
+        return spider.parse_node(response, node)
 
 
 def test_parsed_node_without_link(parsed_node_without_link):
@@ -249,7 +266,15 @@ def parsed_node_missing_scheme():
     response = fake_response_from_string(text=body)
     node = get_node(spider, 'OAI-PMH:record', text=body)
     response.meta["record"] = node.extract_first()
-    return spider.parse_node(response, node)
+
+    with requests_mock.Mocker() as mock:
+        mock.head(
+            'http://www.example.com',
+            headers={
+                'Content-Type': 'text/html',
+            },
+        )
+        return spider.parse_node(response, node)
 
 
 def test_parsed_node_missing_scheme(parsed_node_missing_scheme):

--- a/tests/unit/test_brown.py
+++ b/tests/unit/test_brown.py
@@ -10,15 +10,12 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import json
-
 import pytest
 
 import scrapy
 
 import hepcrawl
-
 from hepcrawl.spiders import brown_spider
-
 from hepcrawl.testlib.fixtures import (
     fake_response_from_file,
     fake_response_from_string,
@@ -56,6 +53,7 @@ def parsed_node():
 
     return spider.parse(response).next()
 
+
 def test_files_constructed(parsed_node):
     """Test pdf link.
 
@@ -66,8 +64,6 @@ def test_files_constructed(parsed_node):
     assert parsed_node.meta["pdf_link"]
     assert parsed_node.meta["pdf_link"] == link
     assert isinstance(parsed_node, scrapy.http.request.Request)
-
-
 
 
 def test_abstract(record):
@@ -111,6 +107,7 @@ def test_abstract(record):
     assert record["abstract"]
     assert record["abstract"] == abstract
 
+
 def test_keywords(record):
     """Test keywords."""
     keywords_gt = ["nanopore", "electrostatic", "DNA", "translocation", "electrode", "integrated"]
@@ -118,6 +115,7 @@ def test_keywords(record):
 
     for key_gt, key in zip(keywords_gt, record["free_keywords"]):
         assert key_gt == key["value"]
+
 
 def test_title(record):
     """Test title."""
@@ -130,10 +128,12 @@ def test_authors(record):
     assert record["authors"]
     assert record["authors"][0]["full_name"] == 'Jiang, Zhijun'
 
+
 def test_date_published(record):
     """Test published date."""
     assert record["date_published"]
     assert record["date_published"] == "2011-01-01"
+
 
 def test_files_scraped(record):
     """Test pdf link.
@@ -144,15 +144,18 @@ def test_files_scraped(record):
     assert record["file_urls"]
     assert record["file_urls"][0] == "http://www.example.com/studio/item/bdr:11303/PDF/"
 
+
 def test_page_nr(record):
     """Test number of pages."""
     assert record["page_nr"]
     assert record["page_nr"] == ["129"]
 
+
 def test_thesis(record):
     """Test thesis year."""
     assert record["thesis"]
     assert record["thesis"]["date"] == "2011"
+
 
 def test_urls(record):
     """Test urls."""
@@ -184,6 +187,7 @@ def parsed_node_no_splash():
 
     return spider.parse(response).next()
 
+
 def test_no_splash(parsed_node_no_splash):
     """Test if parsing a record without splash url results directly in item building.
 
@@ -192,6 +196,7 @@ def test_no_splash(parsed_node_no_splash):
     """
     assert parsed_node_no_splash
     assert isinstance(parsed_node_no_splash, hepcrawl.items.HEPRecord)
+
 
 @pytest.fixture
 def no_year_no_author():
@@ -217,6 +222,7 @@ def test_no_year_in_thesis(no_year_no_author):
     year = spider._get_phd_year(no_year_no_author)
 
     assert not year
+
 
 def test_no_author_in_thesis(no_year_no_author):
     """Test that there are no authors."""

--- a/tests/unit/test_elsevier.py
+++ b/tests/unit/test_elsevier.py
@@ -12,6 +12,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import fnmatch
 
 import pytest
+import requests_mock
 
 from hepcrawl.spiders import elsevier_spider
 
@@ -29,60 +30,74 @@ from hepcrawl.testlib.fixtures import (
 def record():
     """Return results generator from the Elsevier spider."""
     spider = elsevier_spider.ElsevierSpider()
-    response = fake_response_from_file('elsevier/sample_consyn_record.xml')
-    response.meta["xml_url"] = 'elsevier/sample_consyn_record.xml'
-    tag = '//%s' % spider.itertag
-    nodes = get_node(spider, tag, response)
-    parsed_record = spider.parse_node(response, nodes)
-    assert parsed_record
-    return parsed_record
+    with requests_mock.Mocker() as mock:
+        mock.head(
+            'http://www.sciencedirect.com/science/article/pii/sample_consyn_record',
+            headers={
+                'Content-Type': 'text/html',
+            }
+        )
+        response = fake_response_from_file('elsevier/sample_consyn_record.xml')
+        response.meta["xml_url"] = 'elsevier/sample_consyn_record.xml'
+        tag = '//%s' % spider.itertag
+        nodes = get_node(spider, tag, response)
+        parsed_record = spider.parse_node(response, nodes)
+        assert parsed_record
+        return parsed_record
 
 
 @pytest.fixture(scope="module")
 def parsed_node():
     """Test data that have different values than in the sample record."""
     # NOTE: this tries to make a GET request
-    spider = elsevier_spider.ElsevierSpider()
-    body = """
-    <doc xmlns:oa="http://vtw.elsevier.com/data/ns/properties/OpenAccess-1/"
-        xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-        xmlns:dct="http://purl.org/dc/terms/"
-        xmlns:prism="http://prismstandard.org/namespaces/basic/2.0/">
-        <oa:openAccessInformation>
-            <oa:openAccessStatus xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-            http://vtw.elsevier.com/data/voc/oa/OpenAccessStatus#Full
-            </oa:openAccessStatus>
-            <oa:openAccessEffective xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">2014-11-11T08:38:44Z</oa:openAccessEffective>
-            <oa:sponsor xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-            <oa:sponsorName>SCOAP&#xB3; - Sponsoring Consortium for Open Access Publishing in Particle Physics</oa:sponsorName>
-            <oa:sponsorType>http://vtw.elsevier.com/data/voc/oa/SponsorType#FundingBody</oa:sponsorType>
-            </oa:sponsor>
-            <oa:userLicense xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">http://creativecommons.org/licenses/by/3.0/</oa:userLicense>
-        </oa:openAccessInformation>
-        <rdf:Description rdf:about="http://dx.doi.org/10.1016/0370-2693(88)91603-6">
-            <dct:title>Toward classification of conformal theories</dct:title>
-            <prism:doi>10.1016/0370-2693(88)91603-6</prism:doi>
-            <prism:startingPage>421</prism:startingPage>
-            <prism:publicationName>Physics Letters, Section B</prism:publicationName>
-            <prism:volume>206</prism:volume>
-            <dct:creator>Cumrun Vafa</dct:creator>
-            <dct:subject>
-                <rdf:Bag>
-                    <rdf:li>Heavy quarkonia</rdf:li>
-                    <rdf:li>Quark gluon plasma</rdf:li>
-                    <rdf:li>Mott effect</rdf:li>
-                    <rdf:li>X(3872)</rdf:li>
-                </rdf:Bag>
-            </dct:subject>
-        </rdf:Description>
-    </doc>"""
+    with requests_mock.Mocker() as mock:
+        mock.head(
+            'http://www.sciencedirect.com/science/article/pii/sample_consyn_record',
+            headers={
+                'Content-Type': 'text/html',
+            }
+        )
+        spider = elsevier_spider.ElsevierSpider()
+        body = """
+        <doc xmlns:oa="http://vtw.elsevier.com/data/ns/properties/OpenAccess-1/"
+            xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+            xmlns:dct="http://purl.org/dc/terms/"
+            xmlns:prism="http://prismstandard.org/namespaces/basic/2.0/">
+            <oa:openAccessInformation>
+                <oa:openAccessStatus xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                http://vtw.elsevier.com/data/voc/oa/OpenAccessStatus#Full
+                </oa:openAccessStatus>
+                <oa:openAccessEffective xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">2014-11-11T08:38:44Z</oa:openAccessEffective>
+                <oa:sponsor xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <oa:sponsorName>SCOAP&#xB3; - Sponsoring Consortium for Open Access Publishing in Particle Physics</oa:sponsorName>
+                <oa:sponsorType>http://vtw.elsevier.com/data/voc/oa/SponsorType#FundingBody</oa:sponsorType>
+                </oa:sponsor>
+                <oa:userLicense xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">http://creativecommons.org/licenses/by/3.0/</oa:userLicense>
+            </oa:openAccessInformation>
+            <rdf:Description rdf:about="http://dx.doi.org/10.1016/0370-2693(88)91603-6">
+                <dct:title>Toward classification of conformal theories</dct:title>
+                <prism:doi>10.1016/0370-2693(88)91603-6</prism:doi>
+                <prism:startingPage>421</prism:startingPage>
+                <prism:publicationName>Physics Letters, Section B</prism:publicationName>
+                <prism:volume>206</prism:volume>
+                <dct:creator>Cumrun Vafa</dct:creator>
+                <dct:subject>
+                    <rdf:Bag>
+                        <rdf:li>Heavy quarkonia</rdf:li>
+                        <rdf:li>Quark gluon plasma</rdf:li>
+                        <rdf:li>Mott effect</rdf:li>
+                        <rdf:li>X(3872)</rdf:li>
+                    </rdf:Bag>
+                </dct:subject>
+            </rdf:Description>
+        </doc>"""
 
-    response = fake_response_from_string(body)
-    node = get_node(spider, '/doc', response)
-    response.meta["xml_url"] = 'elsevier/sample_consyn_record.xml'
-    parse_response = spider.parse_node(response, node)
-    parse_response.status = 404
-    return spider.scrape_sciencedirect(parse_response)
+        response = fake_response_from_string(body)
+        node = get_node(spider, '/doc', response)
+        response.meta["xml_url"] = 'elsevier/sample_consyn_record.xml'
+        parse_response = spider.parse_node(response, node)
+        parse_response.status = 404
+        return spider.scrape_sciencedirect(parse_response)
 
 
 def test_collection(parsed_node):

--- a/tests/unit/test_phil.py
+++ b/tests/unit/test_phil.py
@@ -12,6 +12,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import json
 
 import pytest
+import requests_mock
 
 from hepcrawl.spiders import phil_spider
 
@@ -36,6 +37,7 @@ def record():
     assert parsed_record
     return parsed_record
 
+
 @pytest.fixture
 def journal():
     """Return results generator from the Phil spider.
@@ -48,6 +50,7 @@ def journal():
     response.meta["jsonrecord"] = jsonrecord[0]
     return spider.build_item(response)
 
+
 @pytest.fixture
 def authors():
     """Returns get_authors() output."""
@@ -56,6 +59,7 @@ def authors():
     jsonrecord = json.loads(response.body_as_unicode())
     response.meta["jsonrecord"] = jsonrecord[0]
     return spider.get_authors(jsonrecord[0]['authors'])
+
 
 @pytest.fixture
 def parse_requests():
@@ -67,16 +71,150 @@ def parse_requests():
     response = fake_response_from_file('phil/test_thesis.json')
     return spider.parse(response)
 
+
 @pytest.fixture
 def splash():
     """Returns a call to build_item(), and ultimately the HEPrecord"""
     spider = phil_spider.PhilSpider()
-    response = fake_response_from_file("phil/fake_splash.html", url="http://philpapers.org/rec/SDFGSDFGDGSDF")
+    response = fake_response_from_file(
+        "phil/fake_splash.html",
+        url="http://philpapers.org/rec/SDFGSDFGDGSDF",
+    )
 
     response.meta["urls"] = [u'http://philpapers.org/rec/SDFGSDFGDGSDF']
     response.meta["jsonrecord"] = {
-        u'publisher': u'', u'doi': None, u'links': [u'http://philpapers.org/rec/SDFGSDFGDGSDF'], u'title': u'Bringing Goodness', u'journal': u'', u'type': u'book', u'abstract': u'Now indulgence dissimilar for his thoroughly has terminated. Agreement offending commanded my an. Change wholly say why eldest period. Are projection put celebrated particular unreserved joy unsatiable its. In then dare good am rose bred or. On am in nearer square wanted.', u'ant_publisher': u'', u'year': u'14/12/2015', u'editors': [], u'collection': u'', u'pages': u'', u'volume': u'0', u'pub_type': u'thesis', u'pubInfo': u'Dissertation, The University of Somewhere', u'authors': [u'Jennings, Bob'], u'issue': u'', u'id': u'SDFGSDFGDGSDF', u'categories': [{u'ancestry': [{u'id': u'5680', u'name': u'Philosophy of Physical Science'}, {u'id': u'5719', u'name': u'Philosophy of Cosmology'}, {u'id': u'5731', u'name': u'Design and Observership in Cosmology'}, {u'id': u'5733', u'name': u'Anthropic Principle'}], u'id': u'5733', u'name': u'Anthropic Principle'}, {u'ancestry': [{u'id': u'5856', u'name': u'Philosophy of Probability'}, {u'id': u'5878', u'name': u'Probabilistic Reasoning'}, {u'id': u'5919', u'name': u'Subjective Probability'}, {u'id': u'5927', u'name': u'Imprecise Credences'}], u'id': u'5927', u'name': u'Imprecise Credences'}, {u'ancestry': [{u'id': u'5932', u'name': u'General Philosophy of Science'}, {u'id': u'6100', u'name': u'Theories and Models'}, {u'id': u'6112', u'name': u'Theoretical Virtues'}, {u'id': u'6122', u'name': u'Simplicity and Parsimony'}], u'id': u'6122', u'name': u'Simplicity and Parsimony'}, {u'ancestry': [{u'id': u'5680', u'name': u'Philosophy of Physical Science'}, {u'id': u'5750', u'name': u'Philosophy of Physics, Miscellaneous'}, {u'id': u'5751', u'name': u'Astrophysics'}], u'id': u'5751', u'name': u'Astrophysics'}, {u'ancestry': [{u'id': u'5856', u'name': u'Philosophy of Probability'}, {u'id': u'5878', u'name': u'Probabilistic Reasoning'}, {u'id': u'5879', u'name': u'Bayesian Reasoning'}, {u'id': u'5881', u'name': u'Bayesian Reasoning, Misc'}], u'id': u'5881', u'name': u'Bayesian Reasoning, Misc'}]
-        }
+        u'publisher': u'',
+        u'doi': None,
+        u'links': [
+            u'http://philpapers.org/rec/SDFGSDFGDGSDF'
+        ],
+        u'title': u'Bringing Goodness',
+        u'journal': u'',
+        u'type': u'book',
+        u'abstract': u'Now indulgence dissimilar for his thoroughly has terminated. Agreement '
+                     u'offending commanded my an. Change wholly say why eldest period. Are pro'
+                     u'jection put celebrated particular unreserved joy unsatiable its. In the'
+                     u'n dare good am rose bred or. On am in nearer square wanted.',
+        u'ant_publisher': u'',
+        u'year': u'14/12/2015',
+        u'editors': [],
+        u'collection': u'',
+        u'pages': u'',
+        u'volume': u'0',
+        u'pub_type': u'thesis',
+        u'pubInfo': u'Dissertation, The University of Somewhere',
+        u'authors': [u'Jennings, Bob'],
+        u'issue': u'',
+        u'id': u'SDFGSDFGDGSDF',
+        u'categories': [
+            {
+                u'ancestry': [
+                    {
+                        u'id': u'5680',
+                        u'name': u'Philosophy of Physical Science'
+                    },
+                    {
+                        u'id': u'5719',
+                        u'name': u'Philosophy of Cosmology'
+                    },
+                    {
+                        u'id': u'5731',
+                        u'name': u'Design and Observership in Cosmology'
+                    },
+                    {
+                        u'id': u'5733',
+                        u'name': u'Anthropic Principle'
+                    }
+                ],
+                u'id': u'5733',
+                u'name': u'Anthropic Principle'
+            },
+            {
+                u'ancestry': [
+                    {
+                        u'id': u'5856',
+                        u'name': u'Philosophy of Probability'
+                    },
+                    {
+                        u'id': u'5878',
+                        u'name': u'Probabilistic Reasoning'
+                    },
+                    {
+                        u'id': u'5919',
+                        u'name': u'Subjective Probability'
+                    },
+                    {
+                        u'id': u'5927',
+                        u'name': u'Imprecise Credences'
+                    }
+                ],
+                u'id': u'5927',
+                u'name': u'Imprecise Credences'
+            },
+            {
+                u'ancestry': [
+                    {
+                        u'id': u'5932',
+                        u'name': u'General Philosophy of Science'
+                    },
+                    {
+                        u'id': u'6100',
+                        u'name': u'Theories and Models'
+                    },
+                    {
+                        u'id': u'6112',
+                        u'name': u'Theoretical Virtues'
+                    },
+                    {
+                        u'id': u'6122',
+                        u'name': u'Simplicity and Parsimony'
+                    }
+                ],
+                u'id': u'6122',
+                u'name': u'Simplicity and Parsimony'
+            },
+            {
+                u'ancestry': [
+                    {
+                        u'id': u'5680',
+                        u'name': u'Philosophy of Physical Science'
+                    },
+                    {
+                        u'id': u'5750',
+                        u'name': u'Philosophy of Physics, Miscellaneous'
+                    },
+                    {
+                        u'id': u'5751',
+                        u'name': u'Astrophysics'
+                    }
+                ],
+                u'id': u'5751',
+                u'name': u'Astrophysics'
+            },
+            {
+                u'ancestry': [
+                    {
+                        u'id': u'5856',
+                        u'name': u'Philosophy of Probability'
+                    },
+                    {
+                        u'id': u'5878',
+                        u'name': u'Probabilistic Reasoning'
+                    },
+                    {
+                        u'id': u'5879',
+                        u'name': u'Bayesian Reasoning'
+                    },
+                    {
+                        u'id': u'5881',
+                        u'name': u'Bayesian Reasoning, Misc'
+                    }
+                ],
+                u'id': u'5881',
+                u'name': u'Bayesian Reasoning, Misc'
+            }
+        ]
+    }
 
     return spider.scrape_for_pdf(response)
 
@@ -85,6 +223,7 @@ def test_scrape(splash):
     """Test pdf link scraping"""
     assert splash["file_urls"]
     assert splash["file_urls"] == [u'http://philpapers.org/www.example.com/file.pdf']
+
 
 def test_parse(parse_requests):
     """Test request metadata that has been defined in parse()."""
@@ -103,6 +242,7 @@ def test_abstract(record):
 
     assert 'abstract' in record
     assert record['abstract'] == abstract
+
 
 def test_title(record):
     """Test extracting title."""
@@ -129,6 +269,7 @@ def test__thesis_authors(record):
     for index, name in enumerate(authors):
         assert unicode(record['authors'][index]['raw_name']) == name
 
+
 def test__journal_authors(journal):
     """Test authors."""
     authors = [u"Jennings, Bob", u"Frederik, Jensen"]
@@ -149,6 +290,7 @@ def test_pdf_link(record):
     assert 'file_urls' in record
     assert record['file_urls'] == files
 
+
 def test_journal(journal):
     """Test journal info getting."""
     title = "Analys"
@@ -157,6 +299,7 @@ def test_journal(journal):
     assert journal['journal_title'] == title
     assert journal['journal_volume'] == volume
     assert journal['journal_issue'] == issue
+
 
 def test_get_authors(authors):
     """Test author getting"""

--- a/tests/unit/test_phil.py
+++ b/tests/unit/test_phil.py
@@ -76,13 +76,20 @@ def parse_requests():
 def splash():
     """Returns a call to build_item(), and ultimately the HEPrecord"""
     spider = phil_spider.PhilSpider()
-    response = fake_response_from_file(
-        "phil/fake_splash.html",
-        url="http://philpapers.org/rec/SDFGSDFGDGSDF",
-    )
 
-    response.meta["urls"] = [u'http://philpapers.org/rec/SDFGSDFGDGSDF']
-    response.meta["jsonrecord"] = {
+    with requests_mock.Mocker() as mock:
+        mock.head(
+            'http://philpapers.org/www.example.com/file.pdf',
+            headers={
+                'Content-Type': 'code; charset=ISO-8859-1',
+            }
+        )
+        response = fake_response_from_file(
+            "phil/fake_splash.html",
+            url="http://philpapers.org/rec/SDFGSDFGDGSDF",
+        )
+        response.meta["urls"] = [u'http://philpapers.org/rec/SDFGSDFGDGSDF']
+        response.meta["jsonrecord"] = {
         u'publisher': u'',
         u'doi': None,
         u'links': [
@@ -216,7 +223,7 @@ def splash():
         ]
     }
 
-    return spider.scrape_for_pdf(response)
+        return spider.scrape_for_pdf(response)
 
 
 def test_scrape(splash):


### PR DESCRIPTION
* Adds: mock connections to external services for `base` spider's unit tests.
* Adds: mock connections to external services for `dnb` spider's unit tests.
* Adds: re-enables skipped unit tests for `dnb` spider.
* Adds: mock connections to external services for `brown` spider's unit tests.
* Adds: mock connections to external services for `elsevier` spider's unit tests.
* Adds: mock connections to external services for `phil` spider's unit tests.

Signed-off-by: Spiros Delviniotis <spirosdelviniotis@gmail.com>