### PR TITLE
tests: add missing crawler2hep unit tests

### DIFF
--- a/tests/unit/responses/crawler2hep/in_generic_crawler_record.yaml
+++ b/tests/unit/responses/crawler2hep/in_generic_crawler_record.yaml
@@ -4,8 +4,8 @@
     ],
     "acquisition_source": {
         "date": "2017-02-21T18:03:40.858985",
-        "source": "TestSpider",
-        "method": "TestSpider",
+        "source": "arXiv",
+        "method": "hepcrawl",
         "submission_number": "scrapy_job"
     },
     "license": [
@@ -26,7 +26,7 @@
     ],
     "titles": [
         {
-            "source": "TestSpider",
+            "source": "arXiv",
             "subtitle": "",
             "title": "You can run, you can hide: The epidemiology and statistical mechanics of zombies"
         }
@@ -36,7 +36,7 @@
             "primary": "HEP"
         },
         {
-            "primary": "CDS"
+            "primary": "CDF-INTERNAL-NOTE"
         },
         {
             "primary": "HEPHIDDEN"
@@ -133,7 +133,7 @@
     ],
     "copyright": [
         {
-            "material": "Article",
+            "material": "publication",
             "holder": "authors",
             "statement": "Published by the American Physical Society",
             "year": "2015"
@@ -141,7 +141,7 @@
     ],
     "abstracts": [
         {
-            "source": "TestSpider",
+            "source": "arXiv",
             "value": "We use a popular fictional disease, zombies, in order to introduce techniques used in modern epidemiology modeling, and ideas and techniques used in the numerical study of critical phenomena. We consider variants of zombie models, from fully connected continuous time dynamics to a full scale exact stochastic dynamic simulation of a zombie outbreak on the continental United States. Along the way, we offer a closed form analytical expression for the fully connected differential equation, and demonstrate that the single person per site two dimensional square lattice version of zombies lies in the percolation universality class. We end with a quantitative study of the full scale US outbreak, including the average susceptibility of different geographical regions."
         }
     ],

--- a/tests/unit/responses/crawler2hep/in_no_document_type.yaml
+++ b/tests/unit/responses/crawler2hep/in_no_document_type.yaml
@@ -6,8 +6,8 @@
     ],
     "acquisition_source": {
         "date": "2017-02-21T18:03:40.858985",
-        "source": "TestSpider",
-        "method": "TestSpider",
+        "source": "arXiv",
+        "method": "hepcrawl",
         "submission_number": "scrapy_job"
     },
     "license": [
@@ -28,7 +28,7 @@
     ],
     "titles": [
         {
-            "source": "TestSpider",
+            "source": "arXiv",
             "subtitle": "",
             "title": "You can run, you can hide: The epidemiology and statistical mechanics of zombies"
         }
@@ -38,7 +38,7 @@
             "primary": "HEP"
         },
         {
-            "primary": "CDS"
+            "primary": "CDF-INTERNAL-NOTE"
         },
         {
             "primary": "HEPHIDDEN"
@@ -126,7 +126,7 @@
     ],
     "copyright": [
         {
-            "material": "Article",
+            "material": "publication",
             "holder": "authors",
             "statement": "Published by the American Physical Society",
             "year": "2015"
@@ -134,7 +134,7 @@
     ],
     "abstracts": [
         {
-            "source": "TestSpider",
+            "source": "arXiv",
             "value": "We use a popular fictional disease, zombies, in order to introduce techniques used in modern epidemiology modeling, and ideas and techniques used in the numerical study of critical phenomena. We consider variants of zombie models, from fully connected continuous time dynamics to a full scale exact stochastic dynamic simulation of a zombie outbreak on the continental United States. Along the way, we offer a closed form analytical expression for the fully connected differential equation, and demonstrate that the single person per site two dimensional square lattice version of zombies lies in the percolation universality class. We end with a quantitative study of the full scale US outbreak, including the average susceptibility of different geographical regions."
         }
     ],

--- a/tests/unit/responses/crawler2hep/out_generic_crawler_record.yaml
+++ b/tests/unit/responses/crawler2hep/out_generic_crawler_record.yaml
@@ -12,6 +12,15 @@
             "license": "CC-BY-3.0"
         }
     ],
+    'number_of_pages': 11,
+    "publication_info": [
+        {
+            "journal_issue": "5",
+            "journal_title": "Phys. Rev. E",
+            "journal_volume": "92",
+            "year": 2015
+        }
+    ],
     "collaborations": [
         {
             "value": "OSQAR Collaboration"
@@ -24,7 +33,7 @@
                     "value": "Laboratory of Atomic and Solid State Physics, Cornell University, Ithaca, New York 14853, USA"
                 }
             ],
-            "full_name": "Alemi,  Alexander A."
+            "full_name": "Alemi, Alexander A."
         },
         {
             "affiliations": [
@@ -32,7 +41,7 @@
                     "value": "Laboratory of Atomic and Solid State Physics, Cornell University, Ithaca, New York 14853, USA"
                 }
             ],
-            "full_name": "Bierbaum,  Matthew"
+            "full_name": "Bierbaum, Matthew"
         },
         {
             "affiliations": [
@@ -43,7 +52,7 @@
                     "value": "Institute of Biotechnology, Cornell University, Ithaca, New York 14853, USA"
                 }
             ],
-            "full_name": "Myers,  Christopher R."
+            "full_name": "Myers, Christopher R."
         },
         {
             "affiliations": [
@@ -51,35 +60,35 @@
                     "value": "Laboratory of Atomic and Solid State Physics, Cornell University, Ithaca, New York 14853, USA"
                 }
             ],
-            "full_name": "Sethna,  James P."
+            "full_name": "Sethna, James P."
         }
     ],
     "titles": [
         {
-            "source": "TestSpider",
+            "source": "arXiv",
             "title": "You can run, you can hide: The epidemiology and statistical mechanics of zombies"
         }
     ],
     "dois": [
         {
-            "source": "hepcrawl",
+            "source": "arXiv",
             "value": "10.1103/PhysRevE.92.052801"
         }
     ],
     "copyright": [
         {
-            "url": "article",
+            "material": "publication",
             "holder": "authors",
             "statement": "Published by the American Physical Society"
         }
     ],
     "imprints": [
         {
-            "date": "2015-11-02T00:00:00"
+            "date": "2015-11-02"
         }
     ],
     "special_collections": [
-        "CDS",
+        "CDF-INTERNAL-NOTE",
         "HEPHIDDEN"
     ],
     "publication_type": [
@@ -89,8 +98,15 @@
     "core": true,
     "withdrawn": true,
     "acquisition_source": {
-        "source": "hepcrawl",
-        "submission_number": "None",
+        "datetime": "2017-02-21T18:03:40.858985",
+        "source": "arXiv",
+        "submission_number": "scrapy_job",
         "method": "hepcrawl"
-    }
+    },
+    "abstracts": [
+        {
+            "source": "arXiv",
+            "value": "We use a popular fictional disease, zombies, in order to introduce techniques used in modern epidemiology modeling, and ideas and techniques used in the numerical study of critical phenomena. We consider variants of zombie models, from fully connected continuous time dynamics to a full scale exact stochastic dynamic simulation of a zombie outbreak on the continental United States. Along the way, we offer a closed form analytical expression for the fully connected differential equation, and demonstrate that the single person per site two dimensional square lattice version of zombies lies in the percolation universality class. We end with a quantitative study of the full scale US outbreak, including the average susceptibility of different geographical regions."
+        }
+    ],
 }

--- a/tests/unit/responses/crawler2hep/out_no_document_type.yaml
+++ b/tests/unit/responses/crawler2hep/out_no_document_type.yaml
@@ -22,7 +22,7 @@
                     "value": "Laboratory of Atomic and Solid State Physics, Cornell University, Ithaca, New York 14853, USA"
                 }
             ],
-            "full_name": "Alemi,  Alexander A."
+            "full_name": "Alemi, Alexander A."
         },
         {
             "affiliations": [
@@ -30,7 +30,7 @@
                     "value": "Laboratory of Atomic and Solid State Physics, Cornell University, Ithaca, New York 14853, USA"
                 }
             ],
-            "full_name": "Bierbaum,  Matthew"
+            "full_name": "Bierbaum, Matthew"
         },
         {
             "affiliations": [
@@ -41,7 +41,7 @@
                     "value": "Institute of Biotechnology, Cornell University, Ithaca, New York 14853, USA"
                 }
             ],
-            "full_name": "Myers,  Christopher R."
+            "full_name": "Myers, Christopher R."
         },
         {
             "affiliations": [
@@ -49,35 +49,35 @@
                     "value": "Laboratory of Atomic and Solid State Physics, Cornell University, Ithaca, New York 14853, USA"
                 }
             ],
-            "full_name": "Sethna,  James P."
+            "full_name": "Sethna, James P."
         }
     ],
     "titles": [
         {
-            "source": "TestSpider",
+            "source": "arXiv",
             "title": "You can run, you can hide: The epidemiology and statistical mechanics of zombies"
         }
     ],
     "dois": [
         {
-            "source": "hepcrawl",
+            "source": "arXiv",
             "value": "10.1103/PhysRevE.92.052801"
         }
     ],
     "copyright": [
         {
-            "url": "article",
             "holder": "authors",
-            "statement": "Published by the American Physical Society"
+            "statement": "Published by the American Physical Society",
+            "material": "publication"
         }
     ],
     "imprints": [
         {
-            "date": "2015-11-02T00:00:00"
+            "date": "2015-11-02"
         }
     ],
     "special_collections": [
-        "CDS",
+        "CDF-INTERNAL-NOTE",
         "HEPHIDDEN"
     ],
     "publication_type": [
@@ -87,8 +87,24 @@
     "core": true,
     "withdrawn": true,
     "acquisition_source": {
-        "source": "hepcrawl",
-        "submission_number": "None",
-        "method": "hepcrawl"
-    }
+        "source": "arXiv",
+        "submission_number": "scrapy_job",
+        "method": "hepcrawl",
+        "datetime": "2017-02-21T18:03:40.858985",
+    },
+    "number_of_pages": 11,
+    "publication_info": [
+        {
+            "journal_issue": "5",
+            "journal_title": "Phys. Rev. E",
+            "journal_volume": "92",
+            "year": 2015
+        }
+    ],
+    'abstracts': [
+        {
+            "source": "arXiv",
+            "value": "We use a popular fictional disease, zombies, in order to introduce techniques used in modern epidemiology modeling, and ideas and techniques used in the numerical study of critical phenomena. We consider variants of zombie models, from fully connected continuous time dynamics to a full scale exact stochastic dynamic simulation of a zombie outbreak on the continental United States. Along the way, we offer a closed form analytical expression for the fully connected differential equation, and demonstrate that the single person per site two dimensional square lattice version of zombies lies in the percolation universality class. We end with a quantitative study of the full scale US outbreak, including the average susceptibility of different geographical regions."
+        }
+    ]
 }

--- a/tests/unit/test_crawler2hep.py
+++ b/tests/unit/test_crawler2hep.py
@@ -38,9 +38,27 @@ def input_generic_crawler_record():
     return load_file('in_generic_crawler_record.yaml')
 
 
+@pytest.fixture('module')
+def expected_no_document_type_record():
+    return load_file('out_no_document_type.yaml')
+
+
+@pytest.fixture('module')
+def input_no_document_type_record():
+    return load_file('in_no_document_type.yaml')
+
+
 def test_generic_crawler_record(
         input_generic_crawler_record,
         expected_generic_crawler_record
 ):
     produced_record = crawler2hep(input_generic_crawler_record)
     assert produced_record == expected_generic_crawler_record
+
+
+def test_no_document_type(
+        input_no_document_type_record,
+        expected_no_document_type_record
+):
+    produced_record = crawler2hep(input_no_document_type_record)
+    assert produced_record == expected_no_document_type_record

--- a/tests/unit/test_crawler2hep.py
+++ b/tests/unit/test_crawler2hep.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of hepcrawl.
+# Copyright (C) 2017 CERN.
+#
+# hepcrawl is a free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see LICENSE file for
+# more details.
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import pytest
+import yaml
+
+from hepcrawl.crawler2hep import crawler2hep
+from hepcrawl.testlib.fixtures import get_test_suite_path
+
+
+def load_file(file_name):
+    path = get_test_suite_path(
+        'responses',
+        'crawler2hep',
+        file_name,
+    )
+    with open(path) as input_data:
+        data = yaml.load(input_data.read())
+
+    return data
+
+
+@pytest.fixture('module')
+def expected_generic_crawler_record():
+    return load_file('out_generic_crawler_record.yaml')
+
+
+@pytest.fixture('module')
+def input_generic_crawler_record():
+    return load_file('in_generic_crawler_record.yaml')
+
+
+def test_generic_crawler_record(
+        input_generic_crawler_record,
+        expected_generic_crawler_record
+):
+    produced_record = crawler2hep(input_generic_crawler_record)
+    assert produced_record == expected_generic_crawler_record


### PR DESCRIPTION
* Updates: current `crawler2hep` unit test responses.
* Adds: `crawler2hep` unit test for generic crawler record.
* Adds: `crawler2hep` unit test for `no document type` record.

Signed-off-by: Spiros Delviniotis <spirosdelviniotis@gmail.com>