### PR TITLE
Generate 'acquisition_source' with literature builder only

### DIFF
--- a/hepcrawl/tohep.py
+++ b/hepcrawl/tohep.py
@@ -139,16 +139,6 @@ def _normalize_hepcrawl_record(item, source):
     return item
 
 
-def _generate_acquisition_source(source):
-    acquisition_source = {
-        'source': source,
-        'method': 'hepcrawl',
-        'datetime': datetime.datetime.now().isoformat(),
-        'submission_number': os.environ.get('SCRAPY_JOB', ''),
-    }
-    return acquisition_source
-
-
 def item_to_hep(
     item,
     source,
@@ -167,9 +157,18 @@ def item_to_hep(
     Raises:
         UnknownItemFormat: if the source item format is unknown.
     """
-    item.record['acquisition_source'] = _generate_acquisition_source(
+    builder = LiteratureBuilder(
         source=source
     )
+
+    builder.add_acquisition_source(
+        source=source,
+        method='hepcrawl',
+        date=datetime.datetime.now().isoformat(),
+        submission_number=os.environ.get('SCRAPY_JOB', ''),
+    )
+
+    item.record['acquisition_source'] = builder.record['acquisition_source']
 
     if item.record_format == 'hep':
         return hep_to_hep(


### PR DESCRIPTION
I removed the redundant function that was used to generate
the 'acquisition_source' and replaced it with the LiteratureBuilder
'add_acquisition_source' method.

Signed-off-by: Iuliana Voinea <iuliana.voinea@student.manchester.ac.uk>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
