### PR TITLE
scrapy: don't use persistent JOBDIR

### DIFF
--- a/hepcrawl/settings.py
+++ b/hepcrawl/settings.py
@@ -130,7 +130,7 @@ CELERY_DISABLE_RATE_LIMITS = True
 
 # Jobs
 # ====
-JOBDIR = "jobs"
+#JOBDIR = "jobs"
 
 # Marc to HEP conversion settings (Desy)
 MARC_TO_HEP_SETTINGS = {

--- a/hepcrawl/spiders/__init__.py
+++ b/hepcrawl/spiders/__init__.py
@@ -8,3 +8,11 @@
 # more details.
 
 from __future__ import absolute_import, division, print_function
+
+from scrapy import Spider
+
+
+class StatefulSpider(Spider):
+    def __init__(self, *args, **kwargs):
+        self.state = {}
+        return super(Spider, self).__init__(*args, **kwargs)

--- a/hepcrawl/spiders/alpha_spider.py
+++ b/hepcrawl/spiders/alpha_spider.py
@@ -18,6 +18,7 @@ from urlparse import urljoin
 from scrapy import Request
 from scrapy.spiders import CrawlSpider
 
+from . import StatefulSpider
 from ..items import HEPRecord
 from ..loaders import HEPLoader
 from ..utils import (
@@ -26,7 +27,7 @@ from ..utils import (
 )
 
 
-class AlphaSpider(CrawlSpider):
+class AlphaSpider(StatefulSpider, CrawlSpider):
 
     """Alpha crawler
 

--- a/hepcrawl/spiders/aps_spider.py
+++ b/hepcrawl/spiders/aps_spider.py
@@ -16,8 +16,9 @@ import link_header
 
 from furl import furl
 
-from scrapy import Request, Spider
+from scrapy import Request
 
+from . import StatefulSpider
 from ..items import HEPRecord
 from ..loaders import HEPLoader
 from ..utils import (
@@ -28,7 +29,7 @@ from ..utils import (
 )
 
 
-class APSSpider(Spider):
+class APSSpider(StatefulSpider):
     """APS crawler.
 
     Uses the APS REST API v2.

--- a/hepcrawl/spiders/arxiv_spider.py
+++ b/hepcrawl/spiders/arxiv_spider.py
@@ -16,6 +16,7 @@ import re
 from scrapy import Request, Selector
 from scrapy.spiders import XMLFeedSpider
 
+from . import StatefulSpider
 from ..items import HEPRecord
 from ..loaders import HEPLoader
 from ..mappings import CONFERENCE_WORDS, THESIS_WORDS
@@ -32,7 +33,7 @@ RE_THESIS = re.compile(r'\b(%s)\b' % '|'.join(
     [re.escape(word) for word in THESIS_WORDS]), re.I | re.U)
 
 
-class ArxivSpider(XMLFeedSpider):
+class ArxivSpider(StatefulSpider, XMLFeedSpider):
     """Spider for crawling arXiv.org OAI-PMH XML files.
 
     Example:

--- a/hepcrawl/spiders/base_spider.py
+++ b/hepcrawl/spiders/base_spider.py
@@ -16,6 +16,7 @@ from urlparse import urljoin
 from scrapy import Request
 from scrapy.spiders import XMLFeedSpider
 
+from . import StatefulSpider
 from ..items import HEPRecord
 from ..loaders import HEPLoader
 from ..utils import (
@@ -26,7 +27,7 @@ from ..utils import (
 )
 
 
-class BaseSpider(XMLFeedSpider):
+class BaseSpider(StatefulSpider, XMLFeedSpider):
 
     """BASE crawler
 

--- a/hepcrawl/spiders/brown_spider.py
+++ b/hepcrawl/spiders/brown_spider.py
@@ -19,6 +19,7 @@ from urlparse import urljoin
 from scrapy import Request
 from scrapy.spiders import CrawlSpider
 
+from . import StatefulSpider
 from ..items import HEPRecord
 from ..loaders import HEPLoader
 from ..utils import (
@@ -29,7 +30,7 @@ from ..utils import (
 )
 
 
-class BrownSpider(CrawlSpider):
+class BrownSpider(StatefulSpider, CrawlSpider):
 
     """Brown crawler
 

--- a/hepcrawl/spiders/desy_spider.py
+++ b/hepcrawl/spiders/desy_spider.py
@@ -16,9 +16,9 @@ from flask.app import Flask
 from inspire_dojson.hep import hep
 from lxml import etree
 from scrapy import Request
-from scrapy.spiders import Spider
 from six.moves import urllib
 
+from . import StatefulSpider
 from ..utils import (
     ftp_list_files,
     ftp_connection_info,
@@ -26,7 +26,7 @@ from ..utils import (
 )
 
 
-class DesySpider(Spider):
+class DesySpider(StatefulSpider):
     """This spider parses files in XML MARC format (collections or single
     records).
 

--- a/hepcrawl/spiders/dnb_spider.py
+++ b/hepcrawl/spiders/dnb_spider.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import, division, print_function
 from scrapy import Request
 from scrapy.spiders import XMLFeedSpider
 
+from . import StatefulSpider
 from ..items import HEPRecord
 from ..loaders import HEPLoader
 from ..utils import (
@@ -24,7 +25,7 @@ from ..utils import (
 )
 
 
-class DNBSpider(XMLFeedSpider):
+class DNBSpider(StatefulSpider, XMLFeedSpider):
 
     """DNB crawler
 

--- a/hepcrawl/spiders/edp_spider.py
+++ b/hepcrawl/spiders/edp_spider.py
@@ -19,6 +19,7 @@ from tempfile import mkdtemp
 from scrapy import Request
 from scrapy.spiders import XMLFeedSpider
 
+from . import StatefulSpider
 from ..extractors.jats import Jats
 from ..items import HEPRecord
 from ..loaders import HEPLoader
@@ -34,7 +35,7 @@ from ..utils import (
 )
 
 
-class EDPSpider(Jats, XMLFeedSpider):
+class EDPSpider(StatefulSpider, Jats, XMLFeedSpider):
     """EDP Sciences crawler.
 
     This spider connects to a given FTP hosts and downloads zip files with
@@ -44,9 +45,10 @@ class EDPSpider(Jats, XMLFeedSpider):
 
     1. First it connects to a FTP host and lists all the new TAR files found
        on the remote server and downloads them to a designated local folder,
-       using ``EDPSpider.start_requests()``. The starting point of the crawl can also be a
-       local file. Packages contain XML files with different formats (``gz`` package
-       is ``JATS``, ``bz2`` package has ``rich`` and ``jp`` format XML files, ``jp`` is ``JATS``.)
+       using ``EDPSpider.start_requests()``. The starting point of the crawl
+       can also be a local file. Packages contain XML files with different
+       formats (``gz`` package is ``JATS``, ``bz2`` package has ``rich`` and
+       ``jp`` format XML files, ``jp`` is ``JATS``.)
 
     2. Then the TAR file is unpacked and it lists all the XML files found
        inside, via ``EDPSpider.handle_package()``. Note the callback from
@@ -59,8 +61,8 @@ class EDPSpider(Jats, XMLFeedSpider):
     5. Finally, ``HEPRecord`` is created in ``EDPSpider.build_item()``.
 
     Examples:
-        To run an ``EDPSpider``, you need to pass FTP connection information via
-        ``ftp_netrc`` file::
+        To run an ``EDPSpider``, you need to pass FTP connection information
+        via ``ftp_netrc`` file::
 
             $ scrapy crawl EDP -a ftp_netrc=tmp/edps_netrc
 

--- a/hepcrawl/spiders/elsevier_spider.py
+++ b/hepcrawl/spiders/elsevier_spider.py
@@ -23,6 +23,7 @@ import requests
 from scrapy import Request
 from scrapy.spiders import XMLFeedSpider
 
+from . import StatefulSpider
 from ..items import HEPRecord
 from ..loaders import HEPLoader
 from ..utils import (
@@ -33,11 +34,10 @@ from ..utils import (
     unzip_xml_files,
     ParsedItem,
 )
-
 from ..dateutils import format_year
 
 
-class ElsevierSpider(XMLFeedSpider):
+class ElsevierSpider(StatefulSpider, XMLFeedSpider):
     """Elsevier crawler.
 
     This spider can scrape either an ATOM feed (default), zip file

--- a/hepcrawl/spiders/hindawi_spider.py
+++ b/hepcrawl/spiders/hindawi_spider.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import, division, print_function
 from scrapy import Request
 from scrapy.spiders import XMLFeedSpider
 
+from . import StatefulSpider
 from ..items import HEPRecord
 from ..loaders import HEPLoader
 from ..utils import (
@@ -22,7 +23,7 @@ from ..utils import (
 )
 
 
-class HindawiSpider(XMLFeedSpider):
+class HindawiSpider(StatefulSpider, XMLFeedSpider):
 
     """Hindawi crawler
 

--- a/hepcrawl/spiders/infn_spider.py
+++ b/hepcrawl/spiders/infn_spider.py
@@ -19,6 +19,7 @@ import requests
 from scrapy.http import Request
 from scrapy.spiders import XMLFeedSpider
 
+from . import StatefulSpider
 from ..items import HEPRecord
 from ..loaders import HEPLoader
 from ..utils import (
@@ -28,7 +29,7 @@ from ..utils import (
 from ..dateutils import format_date
 
 
-class InfnSpider(XMLFeedSpider):
+class InfnSpider(StatefulSpider, XMLFeedSpider):
 
     """INFN crawler
 

--- a/hepcrawl/spiders/iop_spider.py
+++ b/hepcrawl/spiders/iop_spider.py
@@ -12,21 +12,20 @@
 from __future__ import absolute_import, division, print_function
 
 import os
-
 import tarfile
-
 from tempfile import mkdtemp
 
 from scrapy import Request
 from scrapy.spiders import XMLFeedSpider
-from ..extractors.nlm import NLM
 
+from . import StatefulSpider
+from ..extractors.nlm import NLM
 from ..items import HEPRecord
 from ..loaders import HEPLoader
 from ..utils import ParsedItem
 
 
-class IOPSpider(XMLFeedSpider, NLM):
+class IOPSpider(StatefulSpider, XMLFeedSpider, NLM):
     """IOPSpider crawler.
 
     This spider should first be able to harvest files from `IOP STACKS`_.

--- a/hepcrawl/spiders/magic_spider.py
+++ b/hepcrawl/spiders/magic_spider.py
@@ -16,6 +16,7 @@ from urlparse import urljoin
 from scrapy import Request
 from scrapy.spiders import XMLFeedSpider
 
+from . import StatefulSpider
 from ..items import HEPRecord
 from ..loaders import HEPLoader
 from ..utils import (
@@ -24,7 +25,7 @@ from ..utils import (
 )
 
 
-class MagicSpider(XMLFeedSpider):
+class MagicSpider(StatefulSpider, XMLFeedSpider):
 
     """MAGIC crawler
 

--- a/hepcrawl/spiders/mit_spider.py
+++ b/hepcrawl/spiders/mit_spider.py
@@ -21,6 +21,7 @@ import requests
 from scrapy.http import Request
 from scrapy.spiders import XMLFeedSpider
 
+from . import StatefulSpider
 from ..items import HEPRecord
 from ..loaders import HEPLoader
 from ..utils import (
@@ -30,7 +31,7 @@ from ..utils import (
 )
 
 
-class MITSpider(XMLFeedSpider):
+class MITSpider(StatefulSpider, XMLFeedSpider):
 
     """MIT crawler
 

--- a/hepcrawl/spiders/phenix_spider.py
+++ b/hepcrawl/spiders/phenix_spider.py
@@ -16,12 +16,13 @@ from urlparse import urljoin
 from scrapy import Request
 from scrapy.spiders import XMLFeedSpider
 
+from . import StatefulSpider
 from ..items import HEPRecord
 from ..loaders import HEPLoader
 from ..utils import ParsedItem
 
 
-class PhenixSpider(XMLFeedSpider):
+class PhenixSpider(StatefulSpider, XMLFeedSpider):
 
     """PHENIX crawler
 

--- a/hepcrawl/spiders/phil_spider.py
+++ b/hepcrawl/spiders/phil_spider.py
@@ -17,6 +17,7 @@ from urlparse import urljoin
 from scrapy import Request
 from scrapy.spiders import CrawlSpider
 
+from . import StatefulSpider
 from ..items import HEPRecord
 from ..loaders import HEPLoader
 from ..utils import (
@@ -26,7 +27,7 @@ from ..utils import (
 )
 
 
-class PhilSpider(CrawlSpider):
+class PhilSpider(StatefulSpider, CrawlSpider):
 
     """Phil crawler
 

--- a/hepcrawl/spiders/pos_spider.py
+++ b/hepcrawl/spiders/pos_spider.py
@@ -16,8 +16,8 @@ import re
 from urlparse import urljoin
 
 from scrapy import Request, Selector
-from scrapy.spiders import Spider
 
+from . import StatefulSpider
 from ..dateutils import create_valid_date
 from ..items import HEPRecord
 from ..loaders import HEPLoader
@@ -28,7 +28,7 @@ from ..utils import (
 )
 
 
-class POSSpider(Spider):
+class POSSpider(StatefulSpider):
     """POS/Sissa crawler.
 
     Extracts from metadata:

--- a/hepcrawl/spiders/t2k_spider.py
+++ b/hepcrawl/spiders/t2k_spider.py
@@ -16,6 +16,7 @@ from urlparse import urljoin
 from scrapy import Request
 from scrapy.spiders import XMLFeedSpider
 
+from . import StatefulSpider
 from ..items import HEPRecord
 from ..loaders import HEPLoader
 from ..utils import (
@@ -24,7 +25,7 @@ from ..utils import (
 )
 
 
-class T2kSpider(XMLFeedSpider):
+class T2kSpider(StatefulSpider, XMLFeedSpider):
 
     """T2K crawler
 

--- a/hepcrawl/spiders/wsp_spider.py
+++ b/hepcrawl/spiders/wsp_spider.py
@@ -18,6 +18,7 @@ import tempfile
 from scrapy import Request
 from scrapy.spiders import XMLFeedSpider
 
+from . import StatefulSpider
 from ..extractors.jats import Jats
 from ..items import HEPRecord
 from ..loaders import HEPLoader
@@ -31,7 +32,7 @@ from ..utils import (
 )
 
 
-class WorldScientificSpider(Jats, XMLFeedSpider):
+class WorldScientificSpider(StatefulSpider, Jats, XMLFeedSpider):
     """World Scientific Proceedings crawler.
 
     This spider connects to a given FTP hosts and downloads zip files with


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

<!--- Why is this change required? What problem does it solve? -->

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

* The problem is that the JOBDIR has to be unique for each crawl, so
  if it's set as a global setting in scrapy that prevents from running
  crawls in parallel because they collide when using that dir.
  On the other hand, it's a feature that we are not currently using,
  so deactivating it looks like the way to go.

Signed-off-by: David Caro <david@dcaro.es>