### PR TITLE
desy: properly use/populate documents url

### DIFF
--- a/hepcrawl/pipelines.py
+++ b/hepcrawl/pipelines.py
@@ -36,7 +36,7 @@ LOGGER = logging.getLogger(name=__name__)
 
 
 class DocumentsPipeline(FilesPipeline):
-    """Download all the documents provided by record.
+    """Download all the documents the record passed to download.
 
     Note:
 
@@ -55,7 +55,6 @@ class DocumentsPipeline(FilesPipeline):
         )
 
     def get_media_requests(self, item, info):
-        """Download documents using FTP."""
         if item.get('file_urls'):
             logging.info(
                 'Got the following files to download:\n%s' % pprint.pformat(
@@ -70,10 +69,7 @@ class DocumentsPipeline(FilesPipeline):
 
     def get_absolute_file_path(self, path):
         return os.path.abspath(
-            os.path.join(
-                self.store.basedir,
-                path
-            )
+            os.path.join(self.store.basedir, path)
         )
 
     def item_completed(self, results, item, info):

--- a/hepcrawl/utils.py
+++ b/hepcrawl/utils.py
@@ -376,6 +376,16 @@ class RecordFile(object):
 
         self.name = name
 
+    def __repr__(self):
+        return self.__str__()
+
+    def __str__(self):
+        return '%s(path="%s", name="%s")' % (
+            self.__class__.__name__,
+            self.name,
+            self.path,
+        )
+
 
 class ParsedItem(dict):
     """Each of the individual items returned by the spider to the pipeline.

--- a/tests/functional/desy/fixtures/desy_records_ftp_expected.json
+++ b/tests/functional/desy/fixtures/desy_records_ftp_expected.json
@@ -225,7 +225,7 @@
         "core": true, 
         "documents": [
             {
-                "url": "/tmp/file_urls/full/85f78f549bd45b34999bc72353d982127043c341.pdf", 
+                "url": "http://bib-pubdb1.desy.de/record/389977/files/desy-thesis-17-035.title.pdf", 
                 "fulltext": true, 
                 "key": "document"
             }

--- a/tests/functional/desy/fixtures/desy_records_local_expected.json
+++ b/tests/functional/desy/fixtures/desy_records_local_expected.json
@@ -225,7 +225,7 @@
         "core": true, 
         "documents": [
             {
-                "url": "/tmp/file_urls/full/395353fad4fc8ce1c37afe9f019e1473917747e9.pdf", 
+                "url": "http://bib-pubdb1.desy.de/record/389977/files/desy-thesis-17-035.title.pdf", 
                 "fulltext": true, 
                 "key": "document"
             }

--- a/tests/functional/desy/fixtures/ftp_server/DESY/desy_collection_records.xml
+++ b/tests/functional/desy/fixtures/ftp_server/DESY/desy_collection_records.xml
@@ -237,7 +237,7 @@
     <subfield code="u">DESY</subfield>
   </datafield>
   <datafield tag="FFT" ind1=" " ind2=" ">
-    <subfield code="a">FFT/desy-thesis-17-036.title.pdf</subfield>
+    <subfield code="a">http://bib-pubdb1.desy.de/record/389977/files/desy-thesis-17-035.title.pdf</subfield>
     <subfield code="d">Fulltext</subfield>
     <subfield code="t">INSPIRE-PUBLIC</subfield>
   </datafield>


### PR DESCRIPTION
We now have a clear idea on what to support, namely:
* External public urls.
* Internal relative ftp paths.


<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Signed-off-by: David Caro <david@dcaro.es>