### PR TITLE
tests: fix failing tests after DoJSON update

### DIFF
--- a/tests/functional/desy/fixtures/desy_records_ftp_expected.json
+++ b/tests/functional/desy/fixtures/desy_records_ftp_expected.json
@@ -1,6 +1,7 @@
 [
     {
-        "core": true, 
+        "core": true,
+        "citeable": true,
         "documents": [
             {
                 "url": "/tmp/file_urls/full/4467212407c5a5972dc563110d1975e30b8c4450.pdf", 
@@ -221,7 +222,8 @@
         }
     }, 
     {
-        "core": true, 
+        "core": true,
+        "citeable": true,
         "documents": [
             {
                 "url": "http://bib-pubdb1.desy.de/record/389977/files/desy-thesis-17-035.title.pdf", 

--- a/tests/functional/desy/fixtures/desy_records_local_expected.json
+++ b/tests/functional/desy/fixtures/desy_records_local_expected.json
@@ -1,6 +1,7 @@
 [
     {
-        "core": true, 
+        "core": true,
+        "citeable": true,
         "documents": [
             {
                 "url": "/tmp/file_urls/full/53e4ae5ef5adb35d0a7617afe76bf7f324fca2c2.pdf", 
@@ -221,7 +222,8 @@
         }
     }, 
     {
-        "core": true, 
+        "core": true,
+        "citeable": true,
         "documents": [
             {
                 "url": "http://bib-pubdb1.desy.de/record/389977/files/desy-thesis-17-035.title.pdf", 

--- a/tests/unit/responses/desy/desy_collection_records_expected.json
+++ b/tests/unit/responses/desy/desy_collection_records_expected.json
@@ -1,6 +1,7 @@
 [
     {
-        "core": true, 
+        "core": true,
+        "citeable": true,
         "documents": [
             {
                 "url": "http://bib-pubdb1.desy.de/record/389977/files/desy-thesis-17-035.title.pdf", 
@@ -221,7 +222,8 @@
         }
     }, 
     {
-        "core": true, 
+        "core": true,
+        "citeable": true,
         "documents": [
             {
                 "url": "http://bib-pubdb1.desy.de/record/390068/files/desy-thesis-17-036.title.pdf", 

--- a/tests/unit/responses/desy/desy_record_expected.json
+++ b/tests/unit/responses/desy/desy_record_expected.json
@@ -1,5 +1,6 @@
 {
-    "core": true, 
+    "core": true,
+    "citeable": true,
     "documents": [
         {
             "url": "http://bib-pubdb1.desy.de/record/389977/files/desy-thesis-17-035.title.pdf", 


### PR DESCRIPTION
## Related Issue

Due to https://github.com/inspirehep/inspire-dojson/commit/030fda8a00267a831d21264e4e8c3a57b2d04807 change DESY functional tests and some unit tests began failing. This fixes them.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
