### PR TITLE
jats: scrapy handles removing namespaces now

### DIFF
--- a/hepcrawl/parsers/jats.py
+++ b/hepcrawl/parsers/jats.py
@@ -20,8 +20,6 @@ from inspire_schemas.utils import split_page_artid
 from inspire_utils.date import PartialDate
 from inspire_utils.helpers import maybe_int, remove_tags
 
-from lxml import etree  # needed until a new release of parsel is made
-
 from ..utils import get_first, get_node
 
 
@@ -459,7 +457,6 @@ class JatsParser(object):
         else:
             root = jats_record
         root.remove_namespaces()
-        etree.cleanup_namespaces(root.root)
 
         return root
 

--- a/tests/unit/test_edp.py
+++ b/tests/unit/test_edp.py
@@ -587,7 +587,7 @@ def test_references(record_references_only):
         'journal_title': u'J. Nucl. Radiochem. Sci.',
         'journal_volume': u'10',
         'number': u'5a',
-        'raw_reference': u'<mixed-citation xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" publication-type="journal" id="a"><string-name><given-names>R.V.</given-names> <surname>Krishnan</surname></string-name>, <string-name><given-names>G.</given-names> <surname>Panneerselvam</surname></string-name>, <string-name><given-names>P.</given-names> <surname>Manikandan</surname></string-name> <string-name><given-names>M.P.</given-names> <surname>Antony</surname></string-name>, <string-name><given-names>K.</given-names> <surname>Nagarajan</surname></string-name>, <source>J. Nucl. Radiochem. Sci.</source>, <volume>10</volume>.<issue>1</issue>, <fpage>19</fpage>\u2013<lpage>26</lpage> (<year>2009</year>).</mixed-citation>',
+        'raw_reference': u'<mixed-citation publication-type="journal" id="a"><string-name><given-names>R.V.</given-names> <surname>Krishnan</surname></string-name>, <string-name><given-names>G.</given-names> <surname>Panneerselvam</surname></string-name>, <string-name><given-names>P.</given-names> <surname>Manikandan</surname></string-name> <string-name><given-names>M.P.</given-names> <surname>Antony</surname></string-name>, <string-name><given-names>K.</given-names> <surname>Nagarajan</surname></string-name>, <source>J. Nucl. Radiochem. Sci.</source>, <volume>10</volume>.<issue>1</issue>, <fpage>19</fpage>\u2013<lpage>26</lpage> (<year>2009</year>).</mixed-citation>',
         'year': u'2009'
     }
 


### PR DESCRIPTION
Due to scrapy/parsel#99, there is no need to cleanup namespaces in JATS. Also fixes test_references in edp unit test removing the namespace declarations from raw_references.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

  