### PR TITLE
testlibs: fix deep_sort for list case

### DIFF
--- a/hepcrawl/testlib/utils.py
+++ b/hepcrawl/testlib/utils.py
@@ -29,22 +29,13 @@ def get_crawler_instance(crawler_host, *args, **kwargs):
 
 
 def deep_sort(element):
-    """Dummy deep-sort json dicts (lists, dicts, stirngs, bools and integers).
-    """
-    if isinstance(element, str):
-        return element
-
+    """Dummy deep-sort json dicts (lists, dicts, stirngs, bools and integers)."""
     if isinstance(element, dict):
         for key, value in element.items():
             element[key] = deep_sort(value)
-
         return element
 
     if isinstance(element, list):
-        new_element = []
-        for item in sorted(element):
-            new_element.append(deep_sort(item))
-
-        return new_element
+        return sorted([deep_sort(item) for item in element])
 
     return element

--- a/tests/unit/test_testlib_utils.py
+++ b/tests/unit/test_testlib_utils.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of hepcrawl.
+# Copyright (C) 2015, 2016, 2017 CERN.
+#
+# hepcrawl is a free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see LICENSE file for
+# more details.
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from hepcrawl.testlib.utils import deep_sort
+
+
+def test_deep_sort_with_dict_in_list():
+    element = [{'b': {'name': 'bb'}}, {'a': {'name': 'aa'}}]
+    expected_element = [{'a': {'name': 'aa'}}, {'b': {'name': 'bb'}}]
+
+    result = deep_sort(expected_element)
+    assert result == expected_element
+
+
+def test_deep_sort_with_query_parser_output():
+    element = {
+        "bool": {
+            "filter": {
+                "bool": {
+                    "should": [
+                        {
+                            "term": {
+                                "authors.name_variations": "j ellis"
+                            }
+                        },
+                        {
+                            "term": {
+                                "authors.name_variations": "ellis j"
+                            }
+                        }
+                    ]
+                }
+            },
+            "must": {
+                "match": {
+                    "authors.full_name": "ellis, j"
+                }
+            }
+        }
+    }
+
+    expected_element = {
+        "bool": {
+            "filter": {
+                "bool": {
+                    "should": [
+                        {
+                            "term": {
+                                "authors.name_variations": "ellis j"
+                            }
+                        },
+                        {
+                            "term": {
+                                "authors.name_variations": "j ellis"
+                            }
+                        }
+                    ]
+                }
+            },
+            "must": {
+                "match": {
+                    "authors.full_name": "ellis, j"
+                }
+            }
+        }
+    }
+
+    result = deep_sort(expected_element)
+    assert result == expected_element


### PR DESCRIPTION
First deep_sort the inner elements of a list and finally sort the list
itself using sorted.

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>

@david-caro I've added two tests for `deep_sort`, one synthetic and one real world, which is from the output of the parser. 
If there's test data more appropriate for `hepcrawl`, I can see merit in using that, better than the output of the parser.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
