### PR TITLE
oai: retrieve all the records at once

### DIFF
--- a/hepcrawl/spiders/common/oaipmh_spider.py
+++ b/hepcrawl/spiders/common/oaipmh_spider.py
@@ -141,7 +141,11 @@ class OAIPMHSpider(LastRunStoreSpider):
         except NoRecordsMatch as err:
             LOGGER.warning(err)
             raise StopIteration()
-        for record in records:
+
+        # Avoid timing out the resumption token
+        # TODO: implemente a storage-based solution, to be able to handle large
+        #       amounts of records.
+        for record in list(records):
             response = XmlResponse(self.url, encoding='utf-8', body=record.raw)
             selector = Selector(response, type='xml')
             yield self.parse_record(selector)

--- a/hepcrawl/spiders/common/oaipmh_spider.py
+++ b/hepcrawl/spiders/common/oaipmh_spider.py
@@ -131,13 +131,14 @@ class OAIPMHSpider(LastRunStoreSpider):
 
     def parse(self, response):
         sickle = Sickle(self.url)
+        params = {
+            'metadataPrefix': self.format,
+            'set': response.meta['set'],
+            'from': response.meta['from_date'],
+            'until': self.until_date,
+        }
         try:
-            records = sickle.ListRecords(**{
-                'metadataPrefix': self.format,
-                'set': response.meta['set'],
-                'from': response.meta['from_date'],
-                'until': self.until_date,
-            })
+            records = sickle.ListRecords(**params)
         except NoRecordsMatch as err:
             LOGGER.warning(err)
             raise StopIteration()
@@ -145,7 +146,13 @@ class OAIPMHSpider(LastRunStoreSpider):
         # Avoid timing out the resumption token
         # TODO: implemente a storage-based solution, to be able to handle large
         #       amounts of records.
-        for record in list(records):
+        records = list(records)
+        LOGGER.info(
+            'Harvested %s record for params %s',
+            len(records),
+            params,
+        )
+        for record in records:
             response = XmlResponse(self.url, encoding='utf-8', body=record.raw)
             selector = Selector(response, type='xml')
             yield self.parse_record(selector)


### PR DESCRIPTION
When harvesting the whole arXiv, we are getting timed out resumption
tokens.

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

This avoids timing out the connection resumption token.

Signed-off-by: David Caro <david@dcaro.es>