### PR TITLE
utils: strictly check kwargs in spiders (#218)

### DIFF
--- a/hepcrawl/spiders/alpha_spider.py
+++ b/hepcrawl/spiders/alpha_spider.py
@@ -24,6 +24,7 @@ from ..loaders import HEPLoader
 from ..utils import (
     has_numbers,
     ParsedItem,
+    strict_kwargs,
 )
 
 
@@ -49,6 +50,7 @@ class AlphaSpider(StatefulSpider, CrawlSpider):
     domain = "http://alpha.web.cern.ch/"
     itertag = "//div[@class = 'node node-thesis']"
 
+    @strict_kwargs
     def __init__(self, source_file=None, *args, **kwargs):
         """Construct Alpha spider"""
         super(AlphaSpider, self).__init__(*args, **kwargs)

--- a/hepcrawl/spiders/aps_spider.py
+++ b/hepcrawl/spiders/aps_spider.py
@@ -27,6 +27,7 @@ from ..utils import (
     get_nested,
     build_dict,
     ParsedItem,
+    strict_kwargs,
 )
 
 
@@ -47,6 +48,7 @@ class APSSpider(StatefulSpider):
     name = 'APS'
     aps_base_url = "http://harvest.aps.org/v2/journals/articles"
 
+    @strict_kwargs
     def __init__(self, url=None, from_date=None, until_date=None,
                  date="published", journals=None, sets=None, per_page=100,
                  **kwargs):

--- a/hepcrawl/spiders/arxiv_spider.py
+++ b/hepcrawl/spiders/arxiv_spider.py
@@ -63,7 +63,14 @@ class ArxivSpider(OAIPMHSpider):
         until_date=None,
         **kwargs
     ):
-        super(ArxivSpider, self).__init__(**self._all_kwargs)
+        super(ArxivSpider, self).__init__(
+            url=url,
+            format=format,
+            sets=sets,
+            from_date=from_date,
+            until_date=until_date,
+            **kwargs
+        )
 
     def parse_record(self, selector):
         """Parse an arXiv XML exported file into a HEP record."""

--- a/hepcrawl/spiders/arxiv_spider.py
+++ b/hepcrawl/spiders/arxiv_spider.py
@@ -24,6 +24,7 @@ from ..utils import (
     get_licenses,
     split_fullname,
     ParsedItem,
+    strict_kwargs,
 )
 
 RE_CONFERENCE = re.compile(
@@ -47,15 +48,22 @@ class ArxivSpider(OAIPMHSpider):
         Using OAI-PMH XML files::
 
             $ scrapy crawl arXiv \\
-                -a "oai_set=physics:hep-th" -a "from_date=2017-12-13"
+                -a "sets=physics:hep-th" -a "from_date=2017-12-13"
 
     """
     name = 'arXiv'
 
-    def __init__(self, *args, **kwargs):
-        kwargs.setdefault('url', 'http://export.arxiv.org/oai2')
-        kwargs.setdefault('format', 'arXiv')
-        super(ArxivSpider, self).__init__(*args, **kwargs)
+    @strict_kwargs
+    def __init__(
+        self,
+        url='http://export.arxiv.org/oai2',
+        format='arXiv',
+        sets=None,
+        from_date=None,
+        until_date=None,
+        **kwargs
+    ):
+        super(ArxivSpider, self).__init__(**self._all_kwargs)
 
     def parse_record(self, selector):
         """Parse an arXiv XML exported file into a HEP record."""

--- a/hepcrawl/spiders/base_spider.py
+++ b/hepcrawl/spiders/base_spider.py
@@ -24,6 +24,7 @@ from ..utils import (
     parse_domain,
     get_node,
     ParsedItem,
+    strict_kwargs,
 )
 
 
@@ -78,6 +79,7 @@ class BaseSpider(StatefulSpider, XMLFeedSpider):
         ("dc", "http://purl.org/dc/elements/1.1/"),
     ]
 
+    @strict_kwargs
     def __init__(self, source_file=None, *args, **kwargs):
         """Construct BASE spider"""
         super(BaseSpider, self).__init__(*args, **kwargs)

--- a/hepcrawl/spiders/brown_spider.py
+++ b/hepcrawl/spiders/brown_spider.py
@@ -27,6 +27,7 @@ from ..utils import (
     parse_domain,
     get_mime_type,
     ParsedItem,
+    strict_kwargs,
 )
 
 
@@ -63,6 +64,7 @@ class BrownSpider(StatefulSpider, CrawlSpider):
     name = 'brown'
     start_urls = ["https://repository.library.brown.edu/api/collections/355/"]
 
+    @strict_kwargs
     def __init__(self, source_file=None, *args, **kwargs):
         """Construct Brown spider."""
         super(BrownSpider, self).__init__(*args, **kwargs)

--- a/hepcrawl/spiders/cds_spider.py
+++ b/hepcrawl/spiders/cds_spider.py
@@ -21,7 +21,7 @@ from scrapy import Request
 from scrapy.spider import XMLFeedSpider
 
 from . import StatefulSpider
-from ..utils import ParsedItem
+from ..utils import ParsedItem, strict_kwargs
 
 
 class CDSSpider(StatefulSpider, XMLFeedSpider):
@@ -48,6 +48,7 @@ class CDSSpider(StatefulSpider, XMLFeedSpider):
         ('marc', 'http://www.loc.gov/MARC21/slim'),
     ]
 
+    @strict_kwargs
     def __init__(self, source_file=None, **kwargs):
         super(CDSSpider, self).__init__(**kwargs)
         self.source_file = source_file

--- a/hepcrawl/spiders/common/oaipmh_spider.py
+++ b/hepcrawl/spiders/common/oaipmh_spider.py
@@ -21,6 +21,7 @@ from scrapy.http import Request, XmlResponse
 from scrapy.selector import Selector
 
 from .last_run_store import LastRunStoreSpider
+from ...utils import strict_kwargs
 
 
 LOGGER = logging.getLogger(__name__)
@@ -47,6 +48,7 @@ class OAIPMHSpider(LastRunStoreSpider):
     __metaclass__ = abc.ABCMeta
     name = 'OAI-PMH'
 
+    @strict_kwargs
     def __init__(
         self,
         url,
@@ -55,9 +57,9 @@ class OAIPMHSpider(LastRunStoreSpider):
         alias=None,
         from_date=None,
         until_date=None,
-        *args, **kwargs
+        **kwargs
     ):
-        super(OAIPMHSpider, self).__init__(*args, **kwargs)
+        super(OAIPMHSpider, self).__init__(**self._all_kwargs)
         self.url = url
         self.format = format
         if isinstance(sets, string_types):

--- a/hepcrawl/spiders/common/oaipmh_spider.py
+++ b/hepcrawl/spiders/common/oaipmh_spider.py
@@ -59,7 +59,7 @@ class OAIPMHSpider(LastRunStoreSpider):
         until_date=None,
         **kwargs
     ):
-        super(OAIPMHSpider, self).__init__(**self._all_kwargs)
+        super(OAIPMHSpider, self).__init__(**kwargs)
         self.url = url
         self.format = format
         if isinstance(sets, string_types):

--- a/hepcrawl/spiders/desy_spider.py
+++ b/hepcrawl/spiders/desy_spider.py
@@ -23,6 +23,7 @@ from ..utils import (
     ftp_list_files,
     ftp_connection_info,
     ParsedItem,
+    strict_kwargs,
 )
 
 
@@ -71,6 +72,7 @@ class DesySpider(StatefulSpider):
      """
     name = 'desy'
 
+    @strict_kwargs
     def __init__(
         self,
         source_folder=None,

--- a/hepcrawl/spiders/dnb_spider.py
+++ b/hepcrawl/spiders/dnb_spider.py
@@ -22,6 +22,7 @@ from ..utils import (
     parse_domain,
     get_node,
     ParsedItem,
+    strict_kwargs,
 )
 
 
@@ -64,6 +65,7 @@ class DNBSpider(StatefulSpider, XMLFeedSpider):
         ("slim", "http://www.loc.gov/MARC21/slim"),
     ]
 
+    @strict_kwargs
     def __init__(self, source_file=None, *args, **kwargs):
         """Construct DNB spider."""
         super(DNBSpider, self).__init__(*args, **kwargs)

--- a/hepcrawl/spiders/edp_spider.py
+++ b/hepcrawl/spiders/edp_spider.py
@@ -32,6 +32,7 @@ from ..utils import (
     get_node,
     parse_domain,
     ParsedItem,
+    strict_kwargs,
 )
 
 
@@ -123,6 +124,7 @@ class EDPSpider(StatefulSpider, Jats, XMLFeedSpider):
         'EPJ Web of Conferences'
     }
 
+    @strict_kwargs
     def __init__(self, package_path=None, ftp_folder="incoming", ftp_netrc=None, *args, **kwargs):
         """Construct EDP spider.
 

--- a/hepcrawl/spiders/elsevier_spider.py
+++ b/hepcrawl/spiders/elsevier_spider.py
@@ -33,6 +33,7 @@ from ..utils import (
     range_as_string,
     unzip_xml_files,
     ParsedItem,
+    strict_kwargs,
 )
 from ..dateutils import format_year
 
@@ -138,6 +139,7 @@ class ElsevierSpider(StatefulSpider, XMLFeedSpider):
 
     ERROR_CODES = range(400, 432)
 
+    @strict_kwargs
     def __init__(self, atom_feed=None, zip_file=None, xml_file=None, *args, **kwargs):
         """Construct Elsevier spider."""
         super(ElsevierSpider, self).__init__(*args, **kwargs)

--- a/hepcrawl/spiders/hindawi_spider.py
+++ b/hepcrawl/spiders/hindawi_spider.py
@@ -20,6 +20,7 @@ from ..loaders import HEPLoader
 from ..utils import (
     get_licenses,
     ParsedItem,
+    strict_kwargs,
 )
 
 
@@ -69,6 +70,7 @@ class HindawiSpider(StatefulSpider, XMLFeedSpider):
         ("mml", "http://www.w3.org/1998/Math/MathML"),
     ]
 
+    @strict_kwargs
     def __init__(self, source_file=None, *args, **kwargs):
         """Construct Hindawi spider."""
         super(HindawiSpider, self).__init__(*args, **kwargs)

--- a/hepcrawl/spiders/infn_spider.py
+++ b/hepcrawl/spiders/infn_spider.py
@@ -25,6 +25,7 @@ from ..loaders import HEPLoader
 from ..utils import (
     get_temporary_file,
     ParsedItem,
+    strict_kwargs,
 )
 from ..dateutils import format_date
 
@@ -65,6 +66,7 @@ class InfnSpider(StatefulSpider, XMLFeedSpider):
     itertag = "//tr[@onmouseover]"
     today = str(datetime.date.today().year)
 
+    @strict_kwargs
     def __init__(self, source_file=None, year=today, *args, **kwargs):
         """Construct INFN spider"""
         super(InfnSpider, self).__init__(*args, **kwargs)

--- a/hepcrawl/spiders/iop_spider.py
+++ b/hepcrawl/spiders/iop_spider.py
@@ -22,7 +22,7 @@ from . import StatefulSpider
 from ..extractors.nlm import NLM
 from ..items import HEPRecord
 from ..loaders import HEPLoader
-from ..utils import ParsedItem
+from ..utils import ParsedItem, strict_kwargs
 
 
 class IOPSpider(StatefulSpider, XMLFeedSpider, NLM):
@@ -82,6 +82,7 @@ class IOPSpider(StatefulSpider, XMLFeedSpider, NLM):
         # FIXME: add more
     }
 
+    @strict_kwargs
     def __init__(self, zip_file=None, xml_file=None, pdf_files=None, *args, **kwargs):
         """Construct IOP spider."""
         super(IOPSpider, self).__init__(*args, **kwargs)

--- a/hepcrawl/spiders/magic_spider.py
+++ b/hepcrawl/spiders/magic_spider.py
@@ -22,6 +22,7 @@ from ..loaders import HEPLoader
 from ..utils import (
     split_fullname,
     ParsedItem,
+    strict_kwargs,
 )
 
 
@@ -57,6 +58,7 @@ class MagicSpider(StatefulSpider, XMLFeedSpider):
 
     ERROR_CODES = range(400, 432)
 
+    @strict_kwargs
     def __init__(self, source_file=None, *args, **kwargs):
         """Construct MAGIC spider"""
         super(MagicSpider, self).__init__(*args, **kwargs)

--- a/hepcrawl/spiders/mit_spider.py
+++ b/hepcrawl/spiders/mit_spider.py
@@ -28,6 +28,7 @@ from ..utils import (
     get_temporary_file,
     split_fullname,
     ParsedItem,
+    strict_kwargs,
 )
 
 
@@ -63,6 +64,7 @@ class MITSpider(StatefulSpider, XMLFeedSpider):
     itertag = "//ul[@class='ds-artifact-list']/li"
     today = str(datetime.date.today().year)
 
+    @strict_kwargs
     def __init__(self, source_file=None, year=today, *args, **kwargs):
         """Construct MIT spider"""
         super(MITSpider, self).__init__(*args, **kwargs)

--- a/hepcrawl/spiders/phenix_spider.py
+++ b/hepcrawl/spiders/phenix_spider.py
@@ -19,7 +19,7 @@ from scrapy.spiders import XMLFeedSpider
 from . import StatefulSpider
 from ..items import HEPRecord
 from ..loaders import HEPLoader
-from ..utils import ParsedItem
+from ..utils import ParsedItem, strict_kwargs
 
 
 class PhenixSpider(StatefulSpider, XMLFeedSpider):
@@ -50,6 +50,7 @@ class PhenixSpider(StatefulSpider, XMLFeedSpider):
     iterator = "html"
     itertag = "//table//td/ul/li"
 
+    @strict_kwargs
     def __init__(self, source_file=None, *args, **kwargs):
         """Construct PHENIX spider"""
         super(PhenixSpider, self).__init__(*args, **kwargs)

--- a/hepcrawl/spiders/phil_spider.py
+++ b/hepcrawl/spiders/phil_spider.py
@@ -24,6 +24,7 @@ from ..utils import (
     parse_domain,
     get_mime_type,
     ParsedItem,
+    strict_kwargs,
 )
 
 
@@ -57,6 +58,7 @@ class PhilSpider(StatefulSpider, CrawlSpider):
     name = 'phil'
     start_urls = ["http://philpapers.org/philpapers/raw/export/inspire.json"]
 
+    @strict_kwargs
     def __init__(self, source_file=None, *args, **kwargs):
         """Construct Phil spider."""
         super(PhilSpider, self).__init__(*args, **kwargs)

--- a/hepcrawl/spiders/pos_spider.py
+++ b/hepcrawl/spiders/pos_spider.py
@@ -26,6 +26,7 @@ from ..utils import (
     get_licenses,
     get_first,
     ParsedItem,
+    strict_kwargs,
 )
 
 
@@ -76,6 +77,7 @@ class POSSpider(StatefulSpider):
     """
     name = 'pos'
 
+    @strict_kwargs
     def __init__(
         self,
         source_file=None,

--- a/hepcrawl/spiders/t2k_spider.py
+++ b/hepcrawl/spiders/t2k_spider.py
@@ -22,6 +22,7 @@ from ..loaders import HEPLoader
 from ..utils import (
     split_fullname,
     ParsedItem,
+    strict_kwargs,
 )
 
 
@@ -59,6 +60,7 @@ class T2kSpider(StatefulSpider, XMLFeedSpider):
     iterator = "html"
     itertag = "//table[@id='folders']//tr"
 
+    @strict_kwargs
     def __init__(self, source_file=None, *args, **kwargs):
         """Construct T2K spider"""
         super(T2kSpider, self).__init__(*args, **kwargs)

--- a/hepcrawl/spiders/wsp_spider.py
+++ b/hepcrawl/spiders/wsp_spider.py
@@ -26,6 +26,7 @@ from ..utils import (
     local_list_files,
     unzip_xml_files,
     ParsedItem,
+    strict_kwargs,
 )
 
 
@@ -89,6 +90,7 @@ class WorldScientificSpider(StatefulSpider, XMLFeedSpider):
         'rapid-communications'
     ]
 
+    @strict_kwargs
     def __init__(
         self,
         local_package_dir=None,

--- a/hepcrawl/utils.py
+++ b/hepcrawl/utils.py
@@ -419,8 +419,12 @@ def strict_kwargs(func):
 
         if disallowed_kwargs:
             raise TypeError(
-                'Only underscored kwargs allowed in {}. '
-                'Check {} for typos.'.format(repr(func), repr(disallowed_kwargs))
+                'Only underscored kwargs or %s allowed in %s. '
+                'Check %s for typos.' % (
+                    ', '.join(spider_fields),
+                    func,
+                    ', '.join(disallowed_kwargs),
+                )
             )
 
         return func(self, *args, **kwargs)

--- a/hepcrawl/utils.py
+++ b/hepcrawl/utils.py
@@ -392,10 +392,10 @@ def strict_kwargs(func):
     (used by scrapyd), with this we can ensure that we are not passing unwanted
     data by mistake.
 
-    Additionaly this will add all of the 'public' kwargs to an `_init_kwargs`
-    field in the object for easier passing and all of the arguments (including
-    non-overloaded ones) to `_all_kwargs`. (To make passing them forward
-    easier.)
+    Additionaly this will add all of the 'public' not-None kwargs to an
+    `_init_kwargs` field in the object for easier passing and all of the
+    arguments (including non-overloaded ones) to `_all_kwargs`.
+    (To make passing them forward easier.)
 
     Args:
         func (function): a spider method
@@ -434,6 +434,7 @@ def strict_kwargs(func):
         self._init_kwargs = {
             k: v for k, v in defaults.items()
             if not k.startswith('_') and k not in spider_fields
+               and v is not None
         }
         self._all_kwargs = defaults
         return func(self, *args, **kwargs)

--- a/hepcrawl/utils.py
+++ b/hepcrawl/utils.py
@@ -410,13 +410,6 @@ def strict_kwargs(func):
 
     allowed_arguments = defined_arguments + spider_fields
 
-    if argspec.defaults:
-        defaults = dict(
-            zip(argspec.args[-len(argspec.defaults):], argspec.defaults)
-        )
-    else:
-        defaults = {}
-
     @wraps(func)
     def wrapper(self, *args, **kwargs):
         disallowed_kwargs = [
@@ -430,13 +423,6 @@ def strict_kwargs(func):
                 'Check {} for typos.'.format(func, ', '.join(disallowed_kwargs))
             )
 
-        defaults.update(kwargs)
-        self._init_kwargs = {
-            k: v for k, v in defaults.items()
-            if not k.startswith('_') and k not in spider_fields
-               and v is not None
-        }
-        self._all_kwargs = defaults
         return func(self, *args, **kwargs)
     return wrapper
 

--- a/hepcrawl/utils.py
+++ b/hepcrawl/utils.py
@@ -420,7 +420,7 @@ def strict_kwargs(func):
         if disallowed_kwargs:
             raise TypeError(
                 'Only underscored kwargs allowed in {}. '
-                'Check {} for typos.'.format(func, ', '.join(disallowed_kwargs))
+                'Check {} for typos.'.format(repr(func), repr(disallowed_kwargs))
             )
 
         return func(self, *args, **kwargs)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -83,7 +83,7 @@ def dummy_strict_kwargs_cls():
     """A sample class with @strict_kwargs constructor."""
     class Dummy(object):
         @strict_kwargs
-        def __init__(self, a, b=10, c=20, *args, **kwargs):
+        def __init__(self, a, b=10, c=20, d=30, *args, **kwargs):
             pass
 
     return Dummy
@@ -277,10 +277,10 @@ def test_get_journal_and_section_invalid():
 
 def test_strict_kwargs_pass(dummy_strict_kwargs_cls):
     """Test the `strict_kwargs` decorator allowing the kwargs."""
-    dummy = dummy_strict_kwargs_cls(a=1, b=2, _x=4, settings={'DUMMY': True})
+    dummy = dummy_strict_kwargs_cls(a=1, b=2, d=None, _x=4, settings={'DUMMY': True})
     assert dummy._init_kwargs == {'a': 1, 'b': 2, 'c': 20}
     assert dummy._all_kwargs == {
-        'a': 1, 'b': 2, 'c': 20, '_x': 4, 'settings': {'DUMMY': True}
+        'a': 1, 'b': 2, 'c': 20, 'd': None, '_x': 4, 'settings': {'DUMMY': True}
     }
 
 
@@ -288,4 +288,4 @@ def test_strict_kwargs_pass(dummy_strict_kwargs_cls):
 def test_strict_kwargs_fail(dummy_strict_kwargs_cls):
     """Test the `strict_kwargs` decorator disallowing some kwargs."""
     with pytest.raises(TypeError):
-        dummy_strict_kwargs_cls(a=1, b=2, d=4)
+        dummy_strict_kwargs_cls(a=1, b=2, e=4)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -278,11 +278,7 @@ def test_get_journal_and_section_invalid():
 def test_strict_kwargs_pass(dummy_strict_kwargs_cls):
     """Test the `strict_kwargs` decorator allowing the kwargs."""
     dummy = dummy_strict_kwargs_cls(a=1, b=2, d=None, _x=4, settings={'DUMMY': True})
-    assert dummy._init_kwargs == {'a': 1, 'b': 2, 'c': 20}
-    assert dummy._all_kwargs == {
-        'a': 1, 'b': 2, 'c': 20, 'd': None, '_x': 4, 'settings': {'DUMMY': True}
-    }
-
+    assert callable(dummy.__init__)
 
 
 def test_strict_kwargs_fail(dummy_strict_kwargs_cls):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -81,8 +81,13 @@ def list_for_dict():
 class Dummy(object):
     """A sample class with @strict_kwargs constructor."""
     @strict_kwargs
-    def __init__(self, a, b=10, c=20, d=30, *args, **kwargs):
-        pass
+    def __init__(self, good1_no_default, good2=10, good3=20, good4=30, *args, **kwargs):
+        self.good1_no_default = good1_no_default
+        self.good2 = good2
+        self.good3 = good3
+        self.good4 = good4
+        self.args = args
+        self.kwargs = kwargs
 
 
 def test_unzip_xml(zipfile, tmpdir):
@@ -273,11 +278,22 @@ def test_get_journal_and_section_invalid():
 
 def test_strict_kwargs_pass():
     """Test the `strict_kwargs` decorator allowing the kwargs."""
-    dummy = Dummy(a=1, b=2, d=None, _x=4, settings={'DUMMY': True})
+    dummy = Dummy(
+        good1_no_default=1,
+        good2=2,
+        good3=None,
+        _private=4,
+        settings={'DUMMY': True}
+    )
     assert callable(dummy.__init__)
+    assert dummy.good1_no_default == 1
+    assert dummy.good2 == 2
+    assert dummy.good3 == None
+    assert dummy.good4 == 30
+    assert dummy.kwargs == {'_private': 4, 'settings': {'DUMMY': True}}
 
 
 def test_strict_kwargs_fail():
     """Test the `strict_kwargs` decorator disallowing some kwargs."""
     with pytest.raises(TypeError):
-        Dummy(a=1, b=2, e=4)
+        Dummy(**{'good1_no_default': 1, 'good2': 2, u'bąd_þärãm': 4})

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -78,15 +78,11 @@ def list_for_dict():
     ]
 
 
-@pytest.fixture(scope='module')
-def dummy_strict_kwargs_cls():
+class Dummy(object):
     """A sample class with @strict_kwargs constructor."""
-    class Dummy(object):
-        @strict_kwargs
-        def __init__(self, a, b=10, c=20, d=30, *args, **kwargs):
-            pass
-
-    return Dummy
+    @strict_kwargs
+    def __init__(self, a, b=10, c=20, d=30, *args, **kwargs):
+        pass
 
 
 def test_unzip_xml(zipfile, tmpdir):
@@ -275,13 +271,13 @@ def test_get_journal_and_section_invalid():
     assert section == ''
 
 
-def test_strict_kwargs_pass(dummy_strict_kwargs_cls):
+def test_strict_kwargs_pass():
     """Test the `strict_kwargs` decorator allowing the kwargs."""
-    dummy = dummy_strict_kwargs_cls(a=1, b=2, d=None, _x=4, settings={'DUMMY': True})
+    dummy = Dummy(a=1, b=2, d=None, _x=4, settings={'DUMMY': True})
     assert callable(dummy.__init__)
 
 
-def test_strict_kwargs_fail(dummy_strict_kwargs_cls):
+def test_strict_kwargs_fail():
     """Test the `strict_kwargs` decorator disallowing some kwargs."""
     with pytest.raises(TypeError):
-        dummy_strict_kwargs_cls(a=1, b=2, e=4)
+        Dummy(a=1, b=2, e=4)


### PR DESCRIPTION
This introduced a decorator which will disallow any keyword arguments passed to the decorated method that do not begin with an underscore sign in the decorated method. This is mainly to make errors while passing arguments to spiders immediately visible. As we cannot remove kwargs from the spiders' constructors altogether (used internally by scrapyd), with this we can ensure that we are not passing unwanted data by mistake.

Additionaly this will add all of the 'public' kwargs to an `self._init_kwargs` field in the object for easier passing and all of the arguments (including non-overloaded ones) to `self._all_kwargs`. (To make passing them forward easier.)
