### PR TITLE
introduce 'source' to spiders

### DIFF
--- a/hepcrawl/pipelines.py
+++ b/hepcrawl/pipelines.py
@@ -97,7 +97,7 @@ class InspireAPIPushPipeline(object):
         self.results_data = []
 
     def _post_enhance_item(self, item, spider):
-        source = spider.name
+        source = spider.source
 
         enhanced_record = item_to_hep(
             item=item,

--- a/hepcrawl/spiders/__init__.py
+++ b/hepcrawl/spiders/__init__.py
@@ -16,3 +16,7 @@ class StatefulSpider(Spider):
     def __init__(self, *args, **kwargs):
         self.state = {}
         super(StatefulSpider, self).__init__(*args, **kwargs)
+
+    @property
+    def source(self):
+        return self.name

--- a/tests/unit/test_pipelines.py
+++ b/tests/unit/test_pipelines.py
@@ -31,6 +31,7 @@ from hepcrawl.testlib.fixtures import (
 def spider():
     mock_spider = mock.create_autospec(Spider)
     mock_spider.name = 'arXiv'
+    mock_spider.source = 'arXiv'
     mock_spider.state = {}
     return mock_spider
 


### PR DESCRIPTION
## Description
Introduce a field `source` to the base spider that is used to determine the `source` for building `hep` records. Currently the `name` of the spider is used for this, however we want to differentiate these concepts (for use in #217: having two spiders, same source).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
