### PR TITLE
parsers: relax JATS parser date handling

### DIFF
--- a/hepcrawl/parsers/jats.py
+++ b/hepcrawl/parsers/jats.py
@@ -62,7 +62,8 @@ class JatsParser(object):
             self.builder.add_doi(**doi)
         for keyword in self.keywords:
             self.builder.add_keyword(**keyword)
-        self.builder.add_imprint_date(self.publication_date.dumps())
+        if self.publication_date:
+            self.builder.add_imprint_date(self.publication_date.dumps())
         for reference in self.references:
             self.builder.add_reference(reference)
 
@@ -284,11 +285,10 @@ class JatsParser(object):
             './front//pub-date[starts-with(@date-type,"pub")] |'
             './front//date[starts-with(@date-type,"pub")]'
         )
-        publication_date = min(
-            self.get_date(date_node) for date_node in date_nodes
-        )
-
-        return publication_date
+        if date_nodes:
+            return min(
+                self.get_date(date_node) for date_node in date_nodes
+            )
 
     @property
     def publication_info(self):
@@ -366,11 +366,10 @@ class JatsParser(object):
             not_online=not_online
         )
 
-        year = min(
-            self.get_date(date_node) for date_node in date_nodes
-        ).year
-
-        return year
+        if date_nodes:
+            return min(
+                self.get_date(date_node) for date_node in date_nodes
+            ).year
 
     def get_author_affiliations(self, author_node):
         """Extract an author's affiliations."""


### PR DESCRIPTION
## Description
Don't try to add a publication date or year if not available.

## Motivation and Context
Some of the test data for EDP will error the parser unnecessarily. These fields do not need to appear in a valid JATS XML, so we shouldn't assume them to be there.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
