### PR TITLE
utils.strict_kwargs: whitelist crawler_settings param

### DIFF
--- a/hepcrawl/utils.py
+++ b/hepcrawl/utils.py
@@ -406,7 +406,7 @@ def strict_kwargs(func):
     """
     argspec = inspect.getargspec(func)
     defined_arguments = argspec.args[1:]
-    spider_fields = ['settings']
+    spider_fields = ['settings', 'crawler_settings']
 
     allowed_arguments = defined_arguments + spider_fields
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -283,14 +283,15 @@ def test_strict_kwargs_pass():
         good2=2,
         good3=None,
         _private=4,
-        settings={'DUMMY': True}
+        settings={'DUMMY': True},
+        crawler_settings={'DUMMY': True},
     )
     assert callable(dummy.__init__)
     assert dummy.good1_no_default == 1
     assert dummy.good2 == 2
     assert dummy.good3 == None
     assert dummy.good4 == 30
-    assert dummy.kwargs == {'_private': 4, 'settings': {'DUMMY': True}}
+    assert dummy.kwargs == {'_private': 4, 'settings': {'DUMMY': True}, 'crawler_settings': {'DUMMY': True}}
 
 
 def test_strict_kwargs_fail():


### PR DESCRIPTION
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

That parameter is passed when triggering spiders (specially from the
cli).

Signed-off-by: David Caro <david@dcaro.es>