### PR TITLE
desy: make scraping error JSON serializable

### DIFF
--- a/hepcrawl/spiders/desy_spider.py
+++ b/hepcrawl/spiders/desy_spider.py
@@ -287,7 +287,7 @@ class DesySpider(StatefulSpider):
                 try:
                     hep_record = marcxml2record(xml_record)
                 except Exception as e:
-                    return {'xml_record': xml_record, 'error': e,
+                    return {'xml_record': xml_record, 'error': repr(e),
                             'traceback': traceback.format_tb(sys.exc_info()[2])}
                 
             return hep_record

--- a/tests/unit/test_desy.py
+++ b/tests/unit/test_desy.py
@@ -122,5 +122,5 @@ def test_faulty_marc():
     with open(path, 'r') as xmlfile:
         data = xmlfile.read()
     result = spider._hep_records_from_marcxml([data])
-    assert type(result[0]['error']) is ValueError
+    assert result[0]['error'] == "ValueError(u'Unknown string format',)"
     assert result[0].get('traceback') is not None


### PR DESCRIPTION
## Description:
This is a quick fix to avoid raising an exception when spawning the
Celery task that creates the workflow object, as the JSON serializer
used by Celery doesn't know how to serialize exception objects.

A more permanent fix might involve rearchitecting the HEPCrawl items
so that they include the ``errors``, ``traceback`` and perhaps other
keys, in order for inspire-crawler to consume a uniform protocol.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.