### PR TITLE
utils: remove extra get_first

### DIFF
--- a/hepcrawl/utils.py
+++ b/hepcrawl/utils.py
@@ -147,14 +147,6 @@ def list_missing_files(remote_folder, target_folder, file_names):
 
 
 def get_first(iterable, default=None):
-    """Get first item in iterable or default."""
-    if iterable:
-        for item in iterable:
-            return item
-    return default
-
-
-def get_first(iterable, default=None):
     """Get first truthy value from iterable, fall back to default.
 
     This is useful to express a preference among several selectors,


### PR DESCRIPTION
## Description:
[February 20, 2018 2:42 PM](https://gitter.im/inspirehep/inspire-next?at=5a8c25c8a2194eb80d8bdce3)

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.