### PR TITLE
pipelines: return a crawl_result object instead of just the record

### DIFF
--- a/hepcrawl/api.py
+++ b/hepcrawl/api.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of hepcrawl.
+# Copyright (C) 2018 CERN.
+#
+# hepcrawl is a free software; you can redistribute it and/or modify it
+# under the terms of the Revised BD License; see LICENSE file for
+# more details.
+
+import copy
+
+
+class CrawlResult(object):
+    """Representation of a crawling result.
+
+    This class defines the API used by the pipeline to send crawl results.
+
+    Attributes:
+        record (dict): the crawled record.
+        file_name (str): the name of the remote file crawled.
+        source_data (str): content of the remote file crawled.
+        errors (list): list of dictionaries with keys "exception" and
+        "traceback", which collects all the errors occurred during the parsing
+            phase.
+    """
+    def __init__(self, record, file_name="", source_data=""):
+        self.record = record
+        self.file_name = file_name
+        self.source_data = source_data
+        self.errors = []
+
+    def add_error(self, exception_class, traceback):
+        error = {
+            'exception': exception_class,
+            'traceback': traceback
+        }
+        self.errors.append(error)
+
+    @staticmethod
+    def from_parsed_item(parsed_item):
+        result = CrawlResult(
+            record=parsed_item['record'],
+            file_name=parsed_item.get('file_name'),
+            source_data=parsed_item.get('source_data')
+        )
+
+        if parsed_item.get('exception'):
+            result.add_error(
+                parsed_item['exception'],
+                parsed_item['traceback']
+            )
+
+        return result
+
+    def to_dict(self):
+        return copy.deepcopy(self.__dict__)

--- a/hepcrawl/testlib/scrapyd_coverage_runner.py
+++ b/hepcrawl/testlib/scrapyd_coverage_runner.py
@@ -28,8 +28,6 @@ def save_coverage():
 
 
 if __name__ == '__main__':
-    print("\n--------------- CUSTOM SCRAPYD RUNNER ----------------\n")
-
     start_coverage()
     main()
     save_coverage()

--- a/hepcrawl/tohep.py
+++ b/hepcrawl/tohep.py
@@ -23,12 +23,10 @@ Currently there are only two formats for records that we consider:
 
 from __future__ import absolute_import, division, print_function
 
-import os
-import datetime
 import logging
+import os
 
 from inspire_schemas.api import LiteratureBuilder
-
 
 LOGGER = logging.getLogger(__name__)
 
@@ -145,54 +143,6 @@ def _normalize_hepcrawl_record(item, source):
     )
 
     return item
-
-
-def item_to_hep(
-    item,
-    source,
-):
-    """Get an output ready hep formatted record from the given
-    :class:`hepcrawl.utils.ParsedItem`, whatever format it's record might be.
-
-    Args:
-        item(hepcrawl.utils.ParsedItem): item to convert.
-        source(str): string identifying the source for this item (ex. 'arXiv').
-
-    Returns:
-        hepcrawl.utils.ParsedItem: the new item, with the internal record
-            formated as hep record.
-
-    Raises:
-        UnknownItemFormat: if the source item format is unknown.
-    """
-    builder = LiteratureBuilder(
-        source=source
-    )
-
-    builder.add_acquisition_source(
-        source=source,
-        method='hepcrawl',
-        date=datetime.datetime.now().isoformat(),
-        submission_number=os.environ.get('SCRAPY_JOB', ''),
-    )
-
-    item.record['acquisition_source'] = builder.record['acquisition_source']
-
-    if item.record_format == 'hep':
-        return hep_to_hep(
-            hep_record=item.record,
-            record_files=item.record_files,
-        )
-    elif item.record_format == 'hepcrawl':
-        record = _normalize_hepcrawl_record(
-            item=item.record,
-            source=source,
-        )
-        return hepcrawl_to_hep(dict(record))
-    else:
-        raise UnknownItemFormat(
-            'Unknown ParsedItem::{}'.format(item.record_format)
-        )
 
 
 def hep_to_hep(hep_record, record_files):

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ install_requires = [
 tests_require = [
     'check-manifest>=0.25',
     'coverage>=4.0',
+    'freezegun>=0.3.9',
     'isort==4.2.2',
     'pytest>=2.8.0',
     'pytest-cov>=2.1.0',

--- a/tests/functional/arxiv/test_arxiv.py
+++ b/tests/functional/arxiv/test_arxiv.py
@@ -98,7 +98,7 @@ def test_arxiv(
 ):
     crawler = get_crawler_instance(config['CRAWLER_HOST_URL'])
 
-    results = CeleryMonitor.do_crawl(
+    crawl_results = CeleryMonitor.do_crawl(
         app=celery_app,
         monitor_timeout=5,
         monitor_iter_limit=100,
@@ -110,7 +110,9 @@ def test_arxiv(
         **config['CRAWLER_ARGUMENTS']
     )
 
-    gotten_results = [override_generated_fields(result) for result in results]
+    gotten_results = [
+        override_generated_fields(result['record']) for result in crawl_results
+    ]
     expected_results = [
         override_generated_fields(expected) for expected in expected_results
     ]

--- a/tests/functional/cds/test_cds.py
+++ b/tests/functional/cds/test_cds.py
@@ -71,7 +71,7 @@ def test_cds(set_up_local_environment, expected_results):
         set_up_local_environment.get('CRAWLER_HOST_URL')
     )
 
-    results = CeleryMonitor.do_crawl(
+    crawl_results = CeleryMonitor.do_crawl(
         app=celery_app,
         monitor_timeout=5,
         monitor_iter_limit=100,
@@ -83,10 +83,10 @@ def test_cds(set_up_local_environment, expected_results):
         **set_up_local_environment.get('CRAWLER_ARGUMENTS')
     )
 
-    results = deep_sort(
+    crawl_results = deep_sort(
         sorted(
-            results,
-            key=lambda result: result['titles'][0]['title'],
+            crawl_results,
+            key=lambda result: result['record']['titles'][0]['title'],
         )
     )
     expected_results = deep_sort(
@@ -96,7 +96,9 @@ def test_cds(set_up_local_environment, expected_results):
         )
     )
 
-    gotten_results = [override_generated_fields(result) for result in results]
+    gotten_results = [
+        override_generated_fields(result['record']) for result in crawl_results
+    ]
     expected_results = [
         override_generated_fields(expected) for expected in expected_results
     ]
@@ -134,10 +136,10 @@ def test_cds_crawl_twice(set_up_local_environment, expected_results):
         **set_up_local_environment.get('CRAWLER_ARGUMENTS')
     )
 
-    results = deep_sort(
+    crawl_results = deep_sort(
         sorted(
             results,
-            key=lambda result: result['titles'][0]['title'],
+            key=lambda result: result['record']['titles'][0]['title'],
         )
     )
     expected_results = deep_sort(
@@ -147,7 +149,9 @@ def test_cds_crawl_twice(set_up_local_environment, expected_results):
         )
     )
 
-    gotten_results = [override_generated_fields(result) for result in results]
+    gotten_results = [
+        override_generated_fields(result['record']) for result in crawl_results
+    ]
     expected_results = [
         override_generated_fields(expected) for expected in expected_results
     ]

--- a/tests/functional/pos/test_pos.py
+++ b/tests/functional/pos/test_pos.py
@@ -88,7 +88,7 @@ def test_pos_conference_paper_record_and_proceedings_record(
 ):
     crawler = get_crawler_instance(config['CRAWLER_HOST_URL'])
 
-    results = CeleryMonitor.do_crawl(
+    crawl_results = CeleryMonitor.do_crawl(
         app=celery_app,
         monitor_timeout=5,
         monitor_iter_limit=100,
@@ -100,7 +100,9 @@ def test_pos_conference_paper_record_and_proceedings_record(
         **config['CRAWLER_ARGUMENTS']
     )
 
-    gotten_results = [override_generated_fields(result) for result in results]
+    gotten_results = [
+        override_generated_fields(result['record']) for result in crawl_results
+    ]
     expected_results = [
         override_generated_fields(expected) for expected in expected_results
     ]

--- a/tests/functional/wsp/test_wsp.py
+++ b/tests/functional/wsp/test_wsp.py
@@ -127,7 +127,7 @@ def test_wsp(expected_results, settings, cleanup):
         settings.get('CRAWLER_HOST_URL'),
     )
 
-    results = CeleryMonitor.do_crawl(
+    crawl_results = CeleryMonitor.do_crawl(
         app=celery_app,
         monitor_timeout=5,
         monitor_iter_limit=100,
@@ -140,7 +140,7 @@ def test_wsp(expected_results, settings, cleanup):
     )
 
     gotten_results = [
-        override_generated_fields(result) for result in results
+        override_generated_fields(result['record']) for result in crawl_results
     ]
     expected_results = [
         override_generated_fields(expected) for expected in expected_results
@@ -179,7 +179,7 @@ def test_wsp_ftp_crawl_twice(expected_results, settings, cleanup):
         settings.get('CRAWLER_HOST_URL'),
     )
 
-    results = CeleryMonitor.do_crawl(
+    crawl_results = CeleryMonitor.do_crawl(
         app=celery_app,
         monitor_timeout=5,
         monitor_iter_limit=20,
@@ -190,9 +190,8 @@ def test_wsp_ftp_crawl_twice(expected_results, settings, cleanup):
         settings={},
         **settings.get('CRAWLER_ARGUMENTS')
     )
-
     gotten_results = [
-        override_generated_fields(result) for result in results
+        override_generated_fields(result['record']) for result in crawl_results
     ]
     expected_results = [
         override_generated_fields(expected) for expected in expected_results
@@ -200,7 +199,7 @@ def test_wsp_ftp_crawl_twice(expected_results, settings, cleanup):
 
     assert gotten_results == expected_results
 
-    results = CeleryMonitor.do_crawl(
+    crawl_results = CeleryMonitor.do_crawl(
         app=celery_app,
         monitor_timeout=5,
         monitor_iter_limit=20,
@@ -212,6 +211,6 @@ def test_wsp_ftp_crawl_twice(expected_results, settings, cleanup):
         **settings.get('CRAWLER_ARGUMENTS')
     )
 
-    gotten_results = [override_generated_fields(result) for result in results]
+    gotten_results = [override_generated_fields(result) for result in crawl_results]
 
     assert gotten_results == []

--- a/tests/unit/responses/arxiv/sample_arxiv_record10_parsed.json
+++ b/tests/unit/responses/arxiv/sample_arxiv_record10_parsed.json
@@ -50,7 +50,7 @@
                 }
             ], 
             "acquisition_source": {
-                "date": "2016-06-14T00:00:00", 
+                "datetime": "2016-06-14T00:00:00",
                 "source": "arXiv", 
                 "method": "hepcrawl", 
                 "submission_number": "scrapy_job"

--- a/tests/unit/test_arxiv_all.py
+++ b/tests/unit/test_arxiv_all.py
@@ -40,8 +40,8 @@ def many_results(spider):
     records.
     """
     def _get_processed_record(item, spider):
-        record = pipeline.process_item(item, spider)
-        return record
+        crawl_result = pipeline.process_item(item, spider)
+        return crawl_result['record']
 
     fake_response = fake_response_from_file(
         'arxiv/sample_arxiv_record.xml',

--- a/tests/unit/test_arxiv_single.py
+++ b/tests/unit/test_arxiv_single.py
@@ -27,11 +27,11 @@ from hepcrawl.testlib.fixtures import (
 def results():
     """Return results generator from the arxiv spider. All fields, one record.
     """
-    def _get_processed_item(item, spider):
-        record = pipeline.process_item(item, spider)
-        validate(record, 'hep')
-        assert record
-        return record
+    def _get_record_from_processed_item(item, spider):
+        crawl_result = pipeline.process_item(item, spider)
+        validate(crawl_result['record'], 'hep')
+        assert crawl_result
+        return crawl_result['record']
 
     crawler = Crawler(spidercls=arxiv_spider.ArxivSpider)
     spider = arxiv_spider.ArxivSpider.from_crawler(crawler)
@@ -39,14 +39,13 @@ def results():
         'arxiv/sample_arxiv_record0.xml',
         response_type=TextResponse,
     )
-
     test_selectors = fake_response.xpath('.//record')
     parsed_items = [spider.parse_record(sel) for sel in test_selectors]
 
     pipeline = InspireCeleryPushPipeline()
     pipeline.open_spider(spider)
 
-    yield [_get_processed_item(parsed_item, spider) for parsed_item in parsed_items]
+    yield [_get_record_from_processed_item(parsed_item, spider) for parsed_item in parsed_items]
 
     clean_dir()
 
@@ -71,6 +70,7 @@ def test_abstracts(results):
             "detector."
         )
     }]
+
     for record in results:
         assert 'abstracts' in record
         assert record['abstracts'] == expected_abstracts

--- a/tests/unit/test_desy.py
+++ b/tests/unit/test_desy.py
@@ -61,7 +61,7 @@ def get_records(response_file_name):
         pipeline.process_item(
             record,
             spider
-        ) for record in records
+        )['record'] for record in records
     )
 
 
@@ -121,6 +121,7 @@ def test_faulty_marc():
     path = os.path.abspath('tests/unit/responses/desy/faulty_record.xml')
     with open(path, 'r') as xmlfile:
         data = xmlfile.read()
-    result = spider._hep_records_from_marcxml([data])
-    assert result[0]['error'] == "ValueError(u'Unknown string format',)"
-    assert result[0].get('traceback') is not None
+    result = spider._parsed_items_from_marcxml([data])
+    assert result[0].exception == "ValueError(u'Unknown string format',)"
+    assert result[0].traceback is not None
+    assert result[0].source_data is not None

--- a/tests/unit/test_pos.py
+++ b/tests/unit/test_pos.py
@@ -69,10 +69,10 @@ def generated_conference_paper(scrape_pos_conference_paper_page_body):
     pipeline = InspireCeleryPushPipeline()
     pipeline.open_spider(spider)
     parsed_item = request.callback(response).next()
-    parsed_record = pipeline.process_item(parsed_item, spider)
-    assert parsed_record
+    crawl_result = pipeline.process_item(parsed_item, spider)
+    assert crawl_result['record']
 
-    yield parsed_record
+    yield crawl_result['record']
 
     clean_dir()
 

--- a/tests/unit/test_world_scientific.py
+++ b/tests/unit/test_world_scientific.py
@@ -59,7 +59,7 @@ def get_records(response_file_name):
     pipeline.open_spider(spider)
 
     return (
-        pipeline.process_item(record, spider)
+        pipeline.process_item(record, spider)['record']
         for record in records
     )
 


### PR DESCRIPTION
## Description
This commit introduces the model CrawlResult, which wraps the record crawled and eventual errors occurred during the processing, the remote file and the original source. This object is returned when `process_item` is called in the pipeline, instead of either the record crawled or the error traceback.

This commit also changes some unit and functional tests to adapt them to the new API.

* INCOMPATIBLE: this breaks the current API by returning a serialized CrawlResult instead of a record.

Signed-off-by: Antonio Cesarano <cesarano2607@gmail.com>



## Related Issue
https://its.cern.ch/jira/browse/INSPIR-63

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
