### PR TITLE
settings: reorder middlewares

### DIFF
--- a/hepcrawl/settings.py
+++ b/hepcrawl/settings.py
@@ -75,8 +75,8 @@ LAST_RUNS_PATH = os.environ.get(
 # Enable or disable spider middlewares
 # See http://scrapy.readthedocs.org/en/latest/topics/spider-middleware.html
 SPIDER_MIDDLEWARES = {
-    'hepcrawl.middlewares.ErrorHandlingMiddleware': 543,
-    'hepcrawl.middlewares.HepcrawlCrawlOnceMiddleware': 100,
+    'hepcrawl.middlewares.ErrorHandlingMiddleware': 100,
+    'hepcrawl.middlewares.HepcrawlCrawlOnceMiddleware': 200,
 }
 
 # Configure custom downloaders
@@ -89,8 +89,8 @@ DOWNLOAD_HANDLERS = {
 # Enable or disable downloader middlewares
 # See http://scrapy.readthedocs.org/en/latest/topics/downloader-middleware.html
 DOWNLOADER_MIDDLEWARES = {
-    'hepcrawl.middlewares.ErrorHandlingMiddleware': 543,
-    'hepcrawl.middlewares.HepcrawlCrawlOnceMiddleware': 100,
+    'hepcrawl.middlewares.ErrorHandlingMiddleware': 100,
+    'hepcrawl.middlewares.HepcrawlCrawlOnceMiddleware': 200,
 }
 
 CRAWL_ONCE_ENABLED = True

--- a/hepcrawl/settings.py
+++ b/hepcrawl/settings.py
@@ -103,20 +103,20 @@ CRAWL_ONCE_PATH = os.environ.get(
 # Enable or disable extensions
 # See http://scrapy.readthedocs.org/en/latest/topics/extensions.html
 EXTENSIONS = {
-    'hepcrawl.extensions.ErrorHandler': 555,
+    'hepcrawl.extensions.ErrorHandler': 200,
 }
 SENTRY_DSN = os.environ.get('APP_SENTRY_DSN')
 if SENTRY_DSN:
     EXTENSIONS = {
-        'scrapy_sentry.extensions.Errors': 10,
-        'hepcrawl.extensions.ErrorHandler': 555,
+        'scrapy_sentry.extensions.Errors': 100,
+        'hepcrawl.extensions.ErrorHandler': 200,
     }
 
 # Configure item pipelines
 # See http://scrapy.readthedocs.org/en/latest/topics/item-pipeline.html
 ITEM_PIPELINES = {
-    'hepcrawl.pipelines.DocumentsPipeline': 1,
-    'hepcrawl.pipelines.InspireCeleryPushPipeline': 300,
+    'hepcrawl.pipelines.DocumentsPipeline': 100,
+    'hepcrawl.pipelines.InspireCeleryPushPipeline': 200,
 }
 
 # Files Pipeline settings


### PR DESCRIPTION
## Description:
Runs ``ErrorHandlingMiddleware`` before ``HepcrawlOnceMiddleware`` so
that the exceptions raised by the latter are not interpreted as errors
by the former and added to the spider state.

## Related Issue:
Jira: https://its.cern.ch/jira/browse/INSPIR-228

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.