### PR TITLE
utils: make traceback in ParsedItem a string instead of a list

### DIFF
--- a/hepcrawl/spiders/desy_spider.py
+++ b/hepcrawl/spiders/desy_spider.py
@@ -10,6 +10,8 @@
 from __future__ import absolute_import, division, print_function
 
 import os
+import sys
+import traceback
 
 from flask.app import Flask
 from inspire_dojson import marcxml2record
@@ -299,9 +301,11 @@ class DesySpider(StatefulSpider):
                     parsed_items.append(parsed_item)
 
                 except Exception as e:
+                    tb = ''.join(traceback.format_tb(sys.exc_info()[2]))
                     error_parsed_item = ParsedItem.from_exception(
                         record_format='hep',
                         exception=repr(e),
+                        traceback=tb,
                         source_data=xml_record,
                         file_name=file_name
                     )

--- a/hepcrawl/utils.py
+++ b/hepcrawl/utils.py
@@ -492,8 +492,8 @@ class ParsedItem(dict):
             file_name=file_name,
         )
         parsed_item.exception = exception
-        parsed_item.traceback = traceback.format_tb(sys.exc_info()[2]),
-        parsed_item.source_data = source_data,
+        parsed_item.traceback = ''.join(traceback.format_tb(sys.exc_info()[2]))
+        parsed_item.source_data = source_data
         return parsed_item
 
     def to_hep(self, source):

--- a/hepcrawl/utils.py
+++ b/hepcrawl/utils.py
@@ -15,20 +15,16 @@ import fnmatch
 import os
 import pprint
 import re
-import sys
-import traceback
 from functools import wraps
 from operator import itemgetter
 from itertools import groupby
 from netrc import netrc
-from tempfile import mkstemp
 from zipfile import ZipFile
 from urlparse import urlparse
 
 import ftputil
 import ftputil.session
 import ftplib
-import requests
 from hepcrawl.tohep import hep_to_hep, _normalize_hepcrawl_record, \
     hepcrawl_to_hep, UnknownItemFormat
 from inspire_schemas.builders import LiteratureBuilder
@@ -485,14 +481,14 @@ class ParsedItem(dict):
         return pprint.pformat(self)
 
     @staticmethod
-    def from_exception(record_format, exception, source_data, file_name):
+    def from_exception(record_format, exception, traceback, source_data, file_name):
         parsed_item = ParsedItem(
             record={},
             record_format=record_format,
             file_name=file_name,
         )
         parsed_item.exception = exception
-        parsed_item.traceback = ''.join(traceback.format_tb(sys.exc_info()[2]))
+        parsed_item.traceback = traceback
         parsed_item.source_data = source_data
         return parsed_item
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -268,11 +268,12 @@ def test_parsed_item_from_exception():
         item = ParsedItem.from_exception(
             record_format=record_format,
             exception=e,
+            traceback='error traceback',
             source_data=source_data,
             file_name=file_name
         )
 
-        assert type(item['traceback']) is str
+        assert item['traceback'] == 'error traceback'
         assert type(item['exception']) is KeyError
         assert item['source_data'] == 'some XML'
         assert item['file_name'] == 'broken.xml'

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -24,6 +24,7 @@ from hepcrawl.utils import (
     get_node,
     has_numbers,
     parse_domain,
+    ParsedItem,
     range_as_string,
     split_fullname,
     unzip_xml_files,
@@ -254,3 +255,24 @@ def test_strict_kwargs_fail():
     """Test the `strict_kwargs` decorator disallowing some kwargs."""
     with pytest.raises(TypeError):
         Dummy(**{'good1_no_default': 1, 'good2': 2, u'bąd_þärãm': 4})
+
+
+def test_parsed_item_from_exception():
+    record_format = 'hep'
+    source_data = 'some XML'
+    file_name = 'broken.xml'
+
+    try:
+        raise KeyError('this is an error message')
+    except KeyError as e:
+        item = ParsedItem.from_exception(
+            record_format=record_format,
+            exception=e,
+            source_data=source_data,
+            file_name=file_name
+        )
+
+        assert type(item['traceback']) is str
+        assert type(item['exception']) is KeyError
+        assert item['source_data'] == 'some XML'
+        assert item['file_name'] == 'broken.xml'


### PR DESCRIPTION
Signed-off-by: Antonio Cesarano <cesarano2607@gmail.com>

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
