### PR TITLE
tohep: populate raw_affiliations, not affiliations

### DIFF
--- a/hepcrawl/tohep.py
+++ b/hepcrawl/tohep.py
@@ -193,7 +193,7 @@ def hepcrawl_to_hep(crawler_record):
     for author in crawler_record.get('authors', []):
         builder.add_author(builder.make_author(
             full_name=author['full_name'],
-            affiliations=_filter_affiliation(author['affiliations']),
+            raw_affiliations=_filter_affiliation(author['affiliations']),
         ))
 
     for title in crawler_record.get('titles', []):

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ install_requires = [
     'LinkHeader>=0.4.3',
     'furl>=0.4.95',
     'ftputil>=3.3.1',
-    'python-dateutil>=2.4.2',
+    'python-dateutil~=2.0,>=2.7.0',
     'python-scrapyd-api>=2.0.1',
     'harvestingkit>=0.6.12',
     'Sickle~=0.6,>=0.6.2',

--- a/tests/functional/pos/fixtures/pos_conference_proceedings_records.json
+++ b/tests/functional/pos/fixtures/pos_conference_proceedings_records.json
@@ -62,16 +62,18 @@
     ],
     "authors": [
       {
-        "affiliations": [
+        "raw_affiliations": [
           {
+            "source": "pos",
             "value": "INFN and Universit\u00e0 di Firenze"
           }
         ],
         "full_name": "El-Khadra, Aida"
       },
       {
-        "affiliations": [
+        "raw_affiliations": [
           {
+            "source": "pos",
             "value": "U of Pecs"
           }
         ],

--- a/tests/unit/responses/tohep/out_generic_crawler_record.yaml
+++ b/tests/unit/responses/tohep/out_generic_crawler_record.yaml
@@ -30,35 +30,40 @@
     ],
     "authors": [
         {
-            "affiliations": [
+            "raw_affiliations": [
                 {
+                    "source": "arXiv",
                     "value": "Laboratory of Atomic and Solid State Physics, Cornell University, Ithaca, New York 14853, USA"
                 }
             ],
             "full_name": "Alemi, Alexander A."
         },
         {
-            "affiliations": [
+            "raw_affiliations": [
                 {
+                    "source": "arXiv",
                     "value": "Laboratory of Atomic and Solid State Physics, Cornell University, Ithaca, New York 14853, USA"
                 }
             ],
             "full_name": "Bierbaum, Matthew"
         },
         {
-            "affiliations": [
+            "raw_affiliations": [
                 {
+                    "source": "arXiv",
                     "value": "Laboratory of Atomic and Solid State Physics, Cornell University, Ithaca, New York 14853, USA"
                 },
                 {
+                    "source": "arXiv",
                     "value": "Institute of Biotechnology, Cornell University, Ithaca, New York 14853, USA"
                 }
             ],
             "full_name": "Myers, Christopher R."
         },
         {
-            "affiliations": [
+            "raw_affiliations": [
                 {
+                    "source": "arXiv",
                     "value": "Laboratory of Atomic and Solid State Physics, Cornell University, Ithaca, New York 14853, USA"
                 }
             ],

--- a/tests/unit/responses/tohep/out_no_document_type.yaml
+++ b/tests/unit/responses/tohep/out_no_document_type.yaml
@@ -19,35 +19,40 @@
     ],
     "authors": [
         {
-            "affiliations": [
+            "raw_affiliations": [
                 {
+                    "source": "arXiv",
                     "value": "Laboratory of Atomic and Solid State Physics, Cornell University, Ithaca, New York 14853, USA"
                 }
             ],
             "full_name": "Alemi, Alexander A."
         },
         {
-            "affiliations": [
+            "raw_affiliations": [
                 {
+                    "source": "arXiv",
                     "value": "Laboratory of Atomic and Solid State Physics, Cornell University, Ithaca, New York 14853, USA"
                 }
             ],
             "full_name": "Bierbaum, Matthew"
         },
         {
-            "affiliations": [
+            "raw_affiliations": [
                 {
+                    "source": "arXiv",
                     "value": "Laboratory of Atomic and Solid State Physics, Cornell University, Ithaca, New York 14853, USA"
                 },
                 {
+                    "source": "arXiv",
                     "value": "Institute of Biotechnology, Cornell University, Ithaca, New York 14853, USA"
                 }
             ],
             "full_name": "Myers, Christopher R."
         },
         {
-            "affiliations": [
+            "raw_affiliations": [
                 {
+                    "source": "arXiv",
                     "value": "Laboratory of Atomic and Solid State Physics, Cornell University, Ithaca, New York 14853, USA"
                 }
             ],

--- a/tests/unit/test_arxiv_all.py
+++ b/tests/unit/test_arxiv_all.py
@@ -205,7 +205,7 @@ def test_authors(many_results):
         record_affiliations = []
         for author in record['authors']:
             record_affiliations.append(
-                [aff['value'] for aff in author.get('affiliations', [])]
+                [aff['value'] for aff in author.get('raw_affiliations', [])]
             )
         # assert that we have the same list of authors
         assert set(test_full_names) == set(record_full_names)

--- a/tests/unit/test_desy.py
+++ b/tests/unit/test_desy.py
@@ -122,6 +122,6 @@ def test_faulty_marc():
     with open(path, 'r') as xmlfile:
         data = xmlfile.read()
     result = spider._parsed_items_from_marcxml([data])
-    assert result[0].exception == "ValueError(u'Unknown string format',)"
+    assert result[0].exception == "ValueError(u'Unknown string format:', 'Not a date')"
     assert result[0].traceback is not None
     assert result[0].source_data is not None

--- a/tests/unit/test_pos.py
+++ b/tests/unit/test_pos.py
@@ -133,11 +133,21 @@ def test_authors(generated_conference_paper):
     expected_authors = [
         {
             'full_name': 'El-Khadra, Aida',
-            'affiliations': [{'value': 'INFN and Universit\xe0 di Firenze'}],
+            'raw_affiliations': [
+                {
+                    'source': 'pos',
+                    'value': 'INFN and Universit\xe0 di Firenze',
+                },
+            ],
         },
         {
             'full_name': 'MacDonald, M.T.',
-            'affiliations': [{'value': 'U of Pecs'}],
+            'raw_affiliations': [
+                {
+                    'source': 'pos',
+                    'value': 'U of Pecs',
+                },
+            ],
         }
     ]
 
@@ -164,16 +174,18 @@ def test_pipeline_conference_paper(generated_conference_paper):
         },
         'authors': [
             {
-                'affiliations': [
+                'raw_affiliations': [
                     {
+                        'source': 'pos',
                         'value': u'INFN and Universit\xe0 di Firenze'
                     }
                 ],
                 'full_name': u'El-Khadra, Aida'
             },
             {
-                'affiliations': [
+                'raw_affiliations': [
                     {
+                        'source': 'pos',
                         'value': u'U of Pecs'
                     }
                 ],


### PR DESCRIPTION
## Related Issue:
Closes https://github.com/inspirehep/hepcrawl/issues/185 and closes https://github.com/inspirehep/inspire-next/issues/3193.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.