### PR TITLE
This fixes crawlonce for a known file

### DIFF
--- a/hepcrawl/middlewares.py
+++ b/hepcrawl/middlewares.py
@@ -41,6 +41,14 @@ class ErrorHandlingMiddleware(object):
 
     def process_exception(self, request, exception, spider):
         """Register the error in the spider and continue."""
+        if not exception or issubclass(exception, IgnoreRequest):
+            return
+
+        LOGGER.info(
+            "ErrorHandlingMiddleware: Adding error to list:\nexception: %s\nsender: %s",
+            exception,
+            request,
+        )
         spider.state.setdefault('errors', []).append({
             'exception': exception,
             'sender': request,

--- a/hepcrawl/testlib/tasks.py
+++ b/hepcrawl/testlib/tasks.py
@@ -52,4 +52,10 @@ def submit_results(job_id, errors, log_file, results_uri, results_data=None):
     if results_data is None:
         results_data = _extract_results_data(results_path)
 
-    return results_data
+    return {
+        'job_id': job_id,
+        'errors': errors,
+        'log_file': log_file,
+        'results_url': results_uri,
+        'results_data': results_data,
+    }

--- a/tests/functional/arxiv/test_arxiv.py
+++ b/tests/functional/arxiv/test_arxiv.py
@@ -110,8 +110,13 @@ def test_arxiv(
         **config['CRAWLER_ARGUMENTS']
     )
 
+    assert len(crawl_results) == 1
+
+    crawl_result = crawl_results[0]
+
     gotten_results = [
-        override_generated_fields(result['record']) for result in crawl_results
+        override_generated_fields(result['record'])
+        for result in crawl_result['results_data']
     ]
     expected_results = [
         override_generated_fields(expected) for expected in expected_results
@@ -121,3 +126,4 @@ def test_arxiv(
     expected_results = deep_sort(expected_results)
 
     assert gotten_results == expected_results
+    assert not crawl_result['errors']

--- a/tests/functional/cds/test_cds.py
+++ b/tests/functional/cds/test_cds.py
@@ -83,9 +83,13 @@ def test_cds(set_up_local_environment, expected_results):
         **set_up_local_environment.get('CRAWLER_ARGUMENTS')
     )
 
-    crawl_results = deep_sort(
+    assert len(crawl_results) == 1
+
+    crawl_result = crawl_results[0]
+
+    results_records = deep_sort(
         sorted(
-            crawl_results,
+            crawl_result['results_data'],
             key=lambda result: result['record']['titles'][0]['title'],
         )
     )
@@ -97,13 +101,15 @@ def test_cds(set_up_local_environment, expected_results):
     )
 
     gotten_results = [
-        override_generated_fields(result['record']) for result in crawl_results
+        override_generated_fields(result['record'])
+        for result in results_records
     ]
     expected_results = [
         override_generated_fields(expected) for expected in expected_results
     ]
 
     assert gotten_results == expected_results
+    assert not crawl_result['errors']
 
 
 @pytest.mark.parametrize(
@@ -124,9 +130,9 @@ def test_cds_crawl_twice(set_up_local_environment, expected_results):
         set_up_local_environment.get('CRAWLER_HOST_URL')
     )
 
-    results = CeleryMonitor.do_crawl(
+    crawl_results = CeleryMonitor.do_crawl(
         app=celery_app,
-        monitor_timeout=5,
+        monitor_timeout=2,
         monitor_iter_limit=20,
         events_limit=1,
         crawler_instance=crawler,
@@ -136,9 +142,13 @@ def test_cds_crawl_twice(set_up_local_environment, expected_results):
         **set_up_local_environment.get('CRAWLER_ARGUMENTS')
     )
 
-    crawl_results = deep_sort(
+    assert len(crawl_results) == 1
+
+    crawl_result = crawl_results[0]
+
+    results_records = deep_sort(
         sorted(
-            results,
+            crawl_result['results_data'],
             key=lambda result: result['record']['titles'][0]['title'],
         )
     )
@@ -150,17 +160,19 @@ def test_cds_crawl_twice(set_up_local_environment, expected_results):
     )
 
     gotten_results = [
-        override_generated_fields(result['record']) for result in crawl_results
+        override_generated_fields(result['record'])
+        for result in results_records
     ]
     expected_results = [
         override_generated_fields(expected) for expected in expected_results
     ]
 
     assert gotten_results == expected_results
+    assert not crawl_result['errors']
 
-    results = CeleryMonitor.do_crawl(
+    crawl_results = CeleryMonitor.do_crawl(
         app=celery_app,
-        monitor_timeout=5,
+        monitor_timeout=2,
         monitor_iter_limit=20,
         crawler_instance=crawler,
         project=set_up_local_environment.get('CRAWLER_PROJECT'),
@@ -169,6 +181,4 @@ def test_cds_crawl_twice(set_up_local_environment, expected_results):
         **set_up_local_environment.get('CRAWLER_ARGUMENTS')
     )
 
-    gotten_results = [override_generated_fields(result) for result in results]
-
-    assert gotten_results == []
+    assert len(crawl_results) == 0

--- a/tests/functional/desy/test_desy.py
+++ b/tests/functional/desy/test_desy.py
@@ -194,15 +194,18 @@ def test_desy(
         **settings.get('CRAWLER_ARGUMENTS')
     )
 
-    records = [result['record'] for result in crawl_results]
+    crawl_result = crawl_results[0]
 
-    gotten_results = override_dynamic_fields_on_records(records)
+    gotten_records = [
+        result['record'] for result in crawl_result['results_data']
+    ]
+    gotten_records = override_dynamic_fields_on_records(gotten_records)
     expected_results = override_dynamic_fields_on_records(expected_results)
 
-    gotten_results = deep_sort(
+    gotten_records = deep_sort(
         sorted(
-            gotten_results,
-            key=lambda result: result['titles'][0]['title'],
+            gotten_records,
+            key=lambda record: record['titles'][0]['title'],
         )
     )
     expected_results = deep_sort(
@@ -212,7 +215,8 @@ def test_desy(
         )
     )
 
-    assert gotten_results == expected_results
+    assert gotten_records == expected_results
+    assert not crawl_result['errors']
 
 
 def test_desy_broken_xml(get_local_settings_for_broken, cleanup):

--- a/tests/functional/desy/test_desy.py
+++ b/tests/functional/desy/test_desy.py
@@ -186,7 +186,7 @@ def test_desy(
         app=celery_app,
         monitor_timeout=5,
         monitor_iter_limit=100,
-        events_limit=2,
+        events_limit=1,
         crawler_instance=crawler,
         project=settings.get('CRAWLER_PROJECT'),
         spider='desy',

--- a/tests/functional/desy/test_desy.py
+++ b/tests/functional/desy/test_desy.py
@@ -239,6 +239,7 @@ def test_desy_broken_xml(get_local_settings_for_broken, cleanup):
     crawl_result = crawl_results[0]
     result_records = crawl_result['results_data']
 
+    assert not crawl_result['errors']
     assert len(result_records) == 1
     res = result_records[0]
     assert res['record']
@@ -272,7 +273,7 @@ def test_desy_crawl_twice(expected_results, settings, cleanup):
 
     crawl_results = CeleryMonitor.do_crawl(
         app=celery_app,
-        monitor_timeout=2,
+        monitor_timeout=5,
         monitor_iter_limit=100,
         events_limit=1,
         crawler_instance=crawler,
@@ -281,6 +282,8 @@ def test_desy_crawl_twice(expected_results, settings, cleanup):
         settings={},
         **settings.get('CRAWLER_ARGUMENTS')
     )
+
+    assert len(crawl_results) == 1
 
     crawl_result = crawl_results[0]
 
@@ -309,7 +312,7 @@ def test_desy_crawl_twice(expected_results, settings, cleanup):
     # Second crawl
     crawl_results = CeleryMonitor.do_crawl(
         app=celery_app,
-        monitor_timeout=2,
+        monitor_timeout=5,
         monitor_iter_limit=100,
         events_limit=1,
         crawler_instance=crawler,

--- a/tests/functional/desy/test_desy.py
+++ b/tests/functional/desy/test_desy.py
@@ -236,11 +236,87 @@ def test_desy_broken_xml(get_local_settings_for_broken, cleanup):
         settings={},
         **settings.get('CRAWLER_ARGUMENTS')
     )
-    res = crawl_results[0]
+    crawl_result = crawl_results[0]
+    result_records = crawl_result['results_data']
 
+    assert len(result_records) == 1
+    res = result_records[0]
     assert res['record']
     assert len(res['errors']) == 1
     assert 'ValueError' in res['errors'][0]['exception']
     assert res['errors'][0]['traceback']
     assert res['file_name'] == 'broken_record.xml'
     assert res['source_data']
+
+
+@pytest.mark.parametrize(
+    'expected_results, settings',
+    [
+        (
+            expected_json_results_from_file(
+                'desy',
+                'fixtures',
+                'desy_records_ftp_expected.json',
+            ),
+            get_ftp_settings(),
+        ),
+    ],
+    ids=[
+        'ftp package crawl twice',
+    ]
+)
+def test_desy_crawl_twice(expected_results, settings, cleanup):
+    crawler = get_crawler_instance(
+        settings.get('CRAWLER_HOST_URL')
+    )
+
+    crawl_results = CeleryMonitor.do_crawl(
+        app=celery_app,
+        monitor_timeout=2,
+        monitor_iter_limit=100,
+        events_limit=1,
+        crawler_instance=crawler,
+        project=settings.get('CRAWLER_PROJECT'),
+        spider='desy',
+        settings={},
+        **settings.get('CRAWLER_ARGUMENTS')
+    )
+
+    crawl_result = crawl_results[0]
+
+    gotten_records = [
+        result['record'] for result in crawl_result['results_data']
+    ]
+    gotten_records = override_dynamic_fields_on_records(gotten_records)
+    expected_results = override_dynamic_fields_on_records(expected_results)
+
+    gotten_records = deep_sort(
+        sorted(
+            gotten_records,
+            key=lambda record: record['titles'][0]['title'],
+        )
+    )
+    expected_results = deep_sort(
+        sorted(
+            expected_results,
+            key=lambda result: result['titles'][0]['title'],
+        )
+    )
+
+    assert gotten_records == expected_results
+    assert not crawl_result['errors']
+
+    # Second crawl
+    crawl_results = CeleryMonitor.do_crawl(
+        app=celery_app,
+        monitor_timeout=2,
+        monitor_iter_limit=100,
+        events_limit=1,
+        crawler_instance=crawler,
+        project=settings.get('CRAWLER_PROJECT'),
+        spider='desy',
+        settings={},
+        **settings.get('CRAWLER_ARGUMENTS')
+    )
+
+    assert len(crawl_results) == 0

--- a/tests/functional/pos/test_pos.py
+++ b/tests/functional/pos/test_pos.py
@@ -100,8 +100,13 @@ def test_pos_conference_paper_record_and_proceedings_record(
         **config['CRAWLER_ARGUMENTS']
     )
 
+    assert len(crawl_results) == 1
+
+    crawl_result = crawl_results[0]
+
     gotten_results = [
-        override_generated_fields(result['record']) for result in crawl_results
+        override_generated_fields(result['record'])
+        for result in crawl_result['results_data']
     ]
     expected_results = [
         override_generated_fields(expected) for expected in expected_results
@@ -117,6 +122,7 @@ def test_pos_conference_paper_record_and_proceedings_record(
     )
 
     assert gotten_results == expected_results
+    assert not crawl_result['errors']
 
 
 # TODO create test that receives conference paper record AND proceedings

--- a/tests/functional/wsp/test_wsp.py
+++ b/tests/functional/wsp/test_wsp.py
@@ -139,14 +139,20 @@ def test_wsp(expected_results, settings, cleanup):
         **settings.get('CRAWLER_ARGUMENTS')
     )
 
+    assert len(crawl_results) == 1
+
+    crawl_result = crawl_results[0]
+
     gotten_results = [
-        override_generated_fields(result['record']) for result in crawl_results
+        override_generated_fields(result['record'])
+        for result in crawl_result['results_data']
     ]
     expected_results = [
         override_generated_fields(expected) for expected in expected_results
     ]
 
     assert gotten_results == expected_results
+    assert not crawl_result['errors']
 
 
 @pytest.mark.parametrize(
@@ -183,34 +189,40 @@ def test_wsp_ftp_crawl_twice(expected_results, settings, cleanup):
         app=celery_app,
         monitor_timeout=5,
         monitor_iter_limit=20,
-        events_limit=2,
+        events_limit=1,
         crawler_instance=crawler,
         project=settings.get('CRAWLER_PROJECT'),
         spider='WSP',
         settings={},
         **settings.get('CRAWLER_ARGUMENTS')
     )
+
+    assert len(crawl_results) == 1
+
+    crawl_result = crawl_results[0]
+
     gotten_results = [
-        override_generated_fields(result['record']) for result in crawl_results
+        override_generated_fields(result['record'])
+        for result in crawl_result['results_data']
     ]
     expected_results = [
         override_generated_fields(expected) for expected in expected_results
     ]
 
     assert gotten_results == expected_results
+    assert not crawl_result['errors']
 
     crawl_results = CeleryMonitor.do_crawl(
         app=celery_app,
         monitor_timeout=5,
         monitor_iter_limit=20,
-        events_limit=2,
+        events_limit=1,
         crawler_instance=crawler,
         project=settings.get('CRAWLER_PROJECT'),
         spider='WSP',
         settings={},
         **settings.get('CRAWLER_ARGUMENTS')
+
     )
 
-    gotten_results = [override_generated_fields(result) for result in crawl_results]
-
-    assert gotten_results == []
+    assert len(crawl_results) == 0


### PR DESCRIPTION
There are two main fixes:
* In case of errors, send the results to the inspire-crawler
  submit_results task even if there were no records parsed.
  That was used to be able to test the current issue.

* Functional tests: in case of timeout waiting for a task to run,
  don't trow exception, just return empty results.

* Ignore the expected exception `scrapy.exceptions.IgnoreRequest`
  when populating the errors list.


https://its.cern.ch/jira/browse/INSPIR-228

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->