### PR TITLE
crawl-once: use isinstance instead of subclass

### DIFF
--- a/hepcrawl/middlewares.py
+++ b/hepcrawl/middlewares.py
@@ -41,7 +41,7 @@ class ErrorHandlingMiddleware(object):
 
     def process_exception(self, request, exception, spider):
         """Register the error in the spider and continue."""
-        if not exception or issubclass(exception, IgnoreRequest):
+        if not exception or isinstance(exception, IgnoreRequest):
             return
 
         LOGGER.info(

--- a/tests/functional/cds/test_cds.py
+++ b/tests/functional/cds/test_cds.py
@@ -132,7 +132,7 @@ def test_cds_crawl_twice(set_up_local_environment, expected_results):
 
     crawl_results = CeleryMonitor.do_crawl(
         app=celery_app,
-        monitor_timeout=2,
+        monitor_timeout=5,
         monitor_iter_limit=20,
         events_limit=1,
         crawler_instance=crawler,
@@ -172,7 +172,7 @@ def test_cds_crawl_twice(set_up_local_environment, expected_results):
 
     crawl_results = CeleryMonitor.do_crawl(
         app=celery_app,
-        monitor_timeout=2,
+        monitor_timeout=5,
         monitor_iter_limit=20,
         crawler_instance=crawler,
         project=set_up_local_environment.get('CRAWLER_PROJECT'),


### PR DESCRIPTION
In order to properly detect the errors.

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Signed-off-by: David Caro <david@dcaro.es>