### PR TITLE
setup: bump celery to version ~4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of hepcrawl.
-# Copyright (C) 2015, 2016, 2017 CERN.
+# Copyright (C) 2015, 2016, 2017, 2018 CERN.
 #
 # hepcrawl is a free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for
@@ -28,7 +28,7 @@ install_requires = [
     'scrapyd-client>=1.0.1',
     'six>=1.9.0',
     'requests>=2.8.1',
-    'celery>=3.1.23',
+    'celery~=4.0,>=4.1.0,<4.2.0',
     'redis>=2.10.5',
     'pyasn1>=0.1.8',  # Needed for dependency resolving.
     'LinkHeader>=0.4.3',


### PR DESCRIPTION
## Description:
It should be noted that `hepcrawl` has been tested against version 4 of Celery since that version was released due to how the constraint is expressed, so nothing is expected to break here.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.