### PR TITLE
global: change the config for celery 4

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -14,7 +14,7 @@ services:
     image: hepcrawl_base  # hepcrawl_base image is build at pip service of docker-compose.deps.yml
     environment:
       - APP_BROKER_URL=pyamqp://guest:guest@rabbitmq:5672//
-      - APP_CELERY_RESULT_BACKEND=amqp://guest:guest@rabbitmq:5672//
+      - APP_CELERY_RESULT_BACKEND=redis://redis:6379/1
       - APP_CRAWLER_HOST_URL=http://scrapyd:6800
       - APP_API_PIPELINE_TASK_ENDPOINT_DEFAULT=hepcrawl.testlib.tasks.submit_results
       - APP_FILES_STORE=/tmp/file_urls
@@ -77,6 +77,8 @@ services:
     command: celery worker --events --app hepcrawl.testlib.tasks --loglevel=debug
     depends_on:
       rabbitmq:
+        condition: service_healthy
+      redis:
         condition: service_healthy
 
   scrapyd:
@@ -163,6 +165,18 @@ services:
         - "CMD"
         - "rabbitmqctl"
         - "status"
+
+  redis:
+    image: redis:3.2.3
+    healthcheck:
+      timeout: 5s
+      interval: 5s
+      retries: 5
+      test:
+        - "CMD"
+        - "bash"
+        - "-c"
+        - "exec 3<> /dev/tcp/127.0.0.1/6379 && echo PING >&3 && head -1 <&3 | grep PONG"
 
 networks:
   ftp:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -13,7 +13,7 @@ services:
   service_base: &service_base
     image: hepcrawl_base  # hepcrawl_base image is build at pip service of docker-compose.deps.yml
     environment:
-      - APP_BROKER_URL=amqp://guest:guest@rabbitmq:5672//
+      - APP_BROKER_URL=pyamqp://guest:guest@rabbitmq:5672//
       - APP_CELERY_RESULT_BACKEND=amqp://guest:guest@rabbitmq:5672//
       - APP_CRAWLER_HOST_URL=http://scrapyd:6800
       - APP_API_PIPELINE_TASK_ENDPOINT_DEFAULT=hepcrawl.testlib.tasks.submit_results

--- a/hepcrawl/settings.py
+++ b/hepcrawl/settings.py
@@ -141,7 +141,7 @@ API_PIPELINE_TASK_ENDPOINT_MAPPING = {}   # e.g. {'my_spider': 'special.task'}
 # ======
 BROKER_URL = os.environ.get(
     "APP_BROKER_URL",
-    "amqp://guest:guest@rabbitmq:5672//")
+    "pyamqp://guest:guest@rabbitmq:5672//")
 CELERY_RESULT_BACKEND = os.environ.get(
     "APP_CELERY_RESULT_BACKEND",
     "amqp://guest:guest@rabbitmq:5672//")

--- a/hepcrawl/settings.py
+++ b/hepcrawl/settings.py
@@ -144,7 +144,7 @@ BROKER_URL = os.environ.get(
     "pyamqp://guest:guest@rabbitmq:5672//")
 CELERY_RESULT_BACKEND = os.environ.get(
     "APP_CELERY_RESULT_BACKEND",
-    "amqp://guest:guest@rabbitmq:5672//")
+    "redis://redis:6379/1")
 CELERY_ACCEPT_CONTENT = ['json', 'msgpack', 'yaml']
 CELERY_TIMEZONE = 'Europe/Amsterdam'
 CELERY_DISABLE_RATE_LIMITS = True

--- a/hepcrawl/testlib/tasks.py
+++ b/hepcrawl/testlib/tasks.py
@@ -20,7 +20,7 @@ from celery import Celery
 
 class Config(object):
     BROKER_URL = 'pyamqp://guest:guest@rabbitmq:5672//'
-    CELERY_RESULT_BACKEND = 'amqp://guest:guest@rabbitmq:5672//'
+    CELERY_RESULT_BACKEND = 'redis://redis:6379/1'
 
 
 app = Celery()

--- a/hepcrawl/testlib/tasks.py
+++ b/hepcrawl/testlib/tasks.py
@@ -19,11 +19,8 @@ from celery import Celery
 
 
 class Config(object):
-    CELERY_RESULT_BACKEND = "amqp://guest:guest@rabbitmq:5672//"
-    BROKER_URL = "amqp://guest:guest@rabbitmq:5672//"
-    CELERY_ALWAYS_EAGER = True
-    CELERY_CACHE_BACKEND = 'memory'
-    CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
+    BROKER_URL = 'pyamqp://guest:guest@rabbitmq:5672//'
+    CELERY_RESULT_BACKEND = 'amqp://guest:guest@rabbitmq:5672//'
 
 
 app = Celery()


### PR DESCRIPTION
## Description:
https://github.com/inspirehep/hepcrawl/pull/241 forgot to update the configuration for Celery 4, which led to a failure to perform the harvest on QA and https://gitlab.cern.ch/ai/it-puppet-hostgroup-inspire/commit/bb030ed9dea6a231cdedde4d8aa1349f92e91425 to fix it. ~~This PR aims to make the above commit unnecessary.~~ I wasn't able to use `CELERY_BROKER_URL` instead of `BROKER_URL`. I don't know the reason, but all this means is that the above commit is here to stay.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.