### PR TITLE
loaders: avoid truncation of abstracts

### DIFF
--- a/hepcrawl/inputs.py
+++ b/hepcrawl/inputs.py
@@ -100,6 +100,20 @@ def clean_tags_from_affiliations(value):
     return value
 
 
+def convert_comparators_to_tokens(text):
+    """Replaces the characters ``<`` and ``>`` with a token"""
+    text = text.replace("<", "{LOWER_THAN;}")
+    text = text.replace(">", "{GREATER_THAN;}")
+    return text
+
+
+def convert_tokens_to_comparators(text):
+    """Replaces comparator tokens with the correspondent ``<`` or ``>``"""
+    text = text.replace("{LOWER_THAN;}", "<")
+    text = text.replace("{GREATER_THAN;}", ">")
+    return text
+
+
 def clean_collaborations(value):
     """Remove the prefixes for collaborations"""
     return value.replace("for the", "").strip()

--- a/hepcrawl/loaders.py
+++ b/hepcrawl/loaders.py
@@ -26,6 +26,8 @@ from .inputs import (
     clean_tags_from_affiliations,
     clean_collaborations,
     clean_whitespace_characters,
+    convert_comparators_to_tokens,
+    convert_tokens_to_comparators,
     remove_attributes_from_tags,
     translate_language,
     parse_thesis_supervisors,
@@ -77,8 +79,10 @@ class HEPLoader(ItemLoader):
     abstract_in = MapCompose(
         clean_whitespace_characters,
         convert_html_subscripts_to_latex,
+        convert_comparators_to_tokens,
         remove_attributes_from_tags,
         selective_remove_tags(keep=MATHML_ELEMENTS),
+        convert_tokens_to_comparators,
         unicode.strip,
     )
 

--- a/tests/unit/responses/arxiv/sample_arxiv_record.xml
+++ b/tests/unit/responses/arxiv/sample_arxiv_record.xml
@@ -353,5 +353,31 @@
 </arXiv>
 </metadata>
 </record>
+<record>
+<header>
+<identifier>oai:arXiv.org:1808.10515</identifier>
+<datestamp>2018-09-03</datestamp>
+<setSpec>physics:hep-ex</setSpec>
+</header>
+<metadata><arXiv xmlns="http://arxiv.org/OAI/arXiv/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://arxiv.org/OAI/arXiv/ http://arxiv.org/OAI/arXiv.xsd">
+<id>1808.10515</id>
+<created>2018-08-30</created>
+<authors>
+<author>
+<keyname>ATLAS Collaboration</keyname>
+</author>
+<author>
+<keyname>Aaboud</keyname>
+<forenames>Morad</forenames>
+</author>
+</authors>
+<title>A search for pairs of highly collimated photon-jets in $pp$ collisions at $\sqrt{s}$ = 13 TeV with the ATLAS detector</title>
+<categories>hep-ex</categories>
+<comments>43 pages in total, author list starting page 27, 10 figures, 4 tables, submitted to PRD. All figures including auxiliary figures are available at https://atlas.web.cern.ch/Atlas/GROUPS/PHYSICS/PAPERS/EXOT-2017-08</comments>
+<report-no>CERN-EP-2018-143</report-no>
+<license>http://creativecommons.org/licenses/by/4.0/</license>
+<abstract>Results of a search for the pair production of photon-jets---collimated groupings of photons---in the ATLAS detector at the Large Hadron Collider are reported. Highly collimated photon-jets can arise from the decay of new, highly boosted particles that can decay to multiple photons collimated enough to be identified in the electromagnetic calorimeter as a single, photon-like energy cluster. Data from proton--proton collisions at a center-of-mass energy of 13 TeV, corresponding to an integrated luminosity of 36.7 fb$^{-1}$, were collected in 2015 and 2016. Candidate photon-jet pair production events are selected from those containing two reconstructed photons using a set of identification criteria much less stringent than that typically used for the selection of photons, with additional criteria applied to provide improved sensitivity to photon-jets. Narrow excesses in the reconstructed diphoton mass spectra are searched for. The observed mass spectra are consistent with the Standard Model background expectation. The results are interpreted in the context of a model containing a new, high-mass scalar particle with narrow width, $X$, that decays into pairs of photon-jets via new, light particles, $a$. Upper limits are placed on the cross-section times the product of branching ratios $\sigma \times \mathcal{B}(X \rightarrow aa) \times \mathcal {B}(a \rightarrow \gamma \gamma)^{2}$ for 200 GeV $&lt; m_{X} &lt;$ 2 TeV and for ranges of $ m_a $ from a lower mass of 100 MeV up to between 2 GeV and 10 GeV, depending upon $ m_X $. Upper limits are also placed on $\sigma \times \mathcal{B}(X \rightarrow aa) \times \mathcal {B}(a \rightarrow 3\pi^{0})^{2}$ for the same range of $ m_X $ and for ranges of $ m_a $ from a lower mass of 500 MeV up to between 2 GeV and 10 GeV.</abstract></arXiv>
+</metadata>
+</record>
 </GetRecord>
 </OAI-PMH>

--- a/tests/unit/test_arxiv_all.py
+++ b/tests/unit/test_arxiv_all.py
@@ -75,6 +75,7 @@ def test_page_nr(many_results):
         23,
         None,
         None,
+        43,
     ]
     for page_nr, record in zip(page_nrs, many_results):
         assert record.get('number_of_pages') == page_nr
@@ -94,6 +95,7 @@ def test_collections(many_results):
         ['article'],
         ['conference paper'],
         ['thesis'],
+        ['article'],
     ]
 
     for doctypes, record in zip(doctypes, many_results):
@@ -115,6 +117,7 @@ def test_collaborations(many_results):
         ['Super-Kamiokande'],
         ['CMS'],
         [],
+        ['ATLAS'],
     ]
     for num, record in enumerate(many_results):
         collaboration = collaborations[num]
@@ -154,7 +157,8 @@ def test_authors(many_results):
             'de Perio, P.',
         ],
         ['Chudasama, Ruchi', 'Dutta, Dipanwita'],
-        ['Battista, Emmanuele', ]
+        ['Battista, Emmanuele', ],
+        ['Aaboud, Morad'],
     ]
     affiliations = [
         [[], [], [], []],
@@ -192,7 +196,8 @@ def test_authors(many_results):
             ['Department of Physics, University of Toronto']
         ],
         [[], []],
-        [[], ]
+        [[], ],
+        [[]],
     ]
     for num, record in enumerate(many_results):
         test_full_names = full_names[num]
@@ -233,6 +238,10 @@ def test_repno(many_results):
         None,
         None,
         None,
+        [{
+            'value': u'CERN-EP-2018-143',
+            'source': 'arXiv',
+        }]
     ]
     for index, (expected_repno, record) in enumerate(
         zip(expected_repnos, many_results)
@@ -242,3 +251,203 @@ def test_repno(many_results):
             assert record['report_numbers'] == expected_repno
         else:
             assert 'report_numbers' not in record
+
+
+def test_abstracts(many_results):
+    """Test extracting abstracts"""
+    abstracts = [
+        [{
+            'source': 'arXiv',
+            'value': "We study the dynamics of quantum coherence under Unruh thermal noise and seek under which " +
+            "condition the coherence can be frozen in a relativistic setting. We find that the quantum " +
+            "coherence can not be frozen for any acceleration due to the effect of Unruh thermal noise. " +
+            "We also find that quantum coherence is more robust than entanglement under the effect of " +
+            "Unruh thermal noise and therefore the coherence type quantum resources are more accessible " +
+            "for relativistic quantum information processing tasks. Besides, the dynamic of quantum coherence " +
+            "is found to be more sensitive than entanglement to the preparation of the detectors' initial " +
+            "state and the atom-field coupling strength, while it is less sensitive than entanglement to the " +
+            "acceleration of the detector.",
+        }],
+        [{
+            'source': 'arXiv',
+            'value': "In this contribution we summarize the selected highlights of IceCube in thedomain of high-energy " +
+            "astrophysics and particle physics. We discuss thehighest-energy neutrino detection and its " +
+            "interpretation after 4 years of data.The significance is such that the discovery of a non " +
+            "terrestrial component canbe claimed but its origin is not yet clarified. The high energy " +
+            "non-atmosphericcomponent is seen also in other analyses with smaller significance, forinstance " +
+            "when using muon neutrino induced events coming from the Northernhemisphere. Flavor mixing " +
+            "is probed along cosmic distances in an analysis usingalso cascade neutrino events. The results " +
+            "on the search for neutrino sources ispresented including the results of a joint analysis with " +
+            "Pierre Auger andTelescope Array which is sensitive to correlations between highest energyneutrinos " +
+            "and UHECRs measured by the three experiments. Moreover, recentresults on dark matter searches " +
+            "from the Sun are discussed. Finally, theresults on standard neutrino oscillations are presented.",
+        }],
+        [{
+            'source': 'arXiv',
+            'value': "We discuss the fate of the axial U(1) symmetry in 2-flavor QCD at finitetemperature, where " +
+            "the non-singlet chiral symmetry is restored. We firstsummarize the previous theoretical " +
+            "investigation on the relation between theeigenvalue density of the Dirac operator and the " +
+            "axial U(1) symmetry. We showthat the eigenvalue density near the origin behaves as $\lambda^\gamma$ " +
+            "with$\gamma > 2$ in the chirally symmetric phase, where $\lambda$ is an eigenvalue.This " +
+            "implies that the axial U(1) symmetry is partially restored, so that thelow energy symmetry " +
+            "of the theory becomes SU(2)$\otimes$ SU(2)$\otimes$ Z$_4$.Secondly, we report recent numerical " +
+            "investigations on this issue by latticeQCD simulations with lattice chiral fermions such as " +
+            "Overlap or improveddomain-wall fermions. Our preliminary results indicate that the eigenvaluedensity " +
+            "seems to have a gap at the origin just above $T_c$, the temperature ofthe chiral symmetry " +
+            "restoration, which implies the axial U(1) symmetry iseffectively restored at high temperature. " +
+            "We also point out an importance ofthe exact lattice chiral symmetry to obtain correct results " +
+            "on this issue.",
+        }],
+        [{
+            'source': 'arXiv',
+            'value': "Recent neutrino oscillation results have shown that the existing longbaseline experiments " +
+            "have some sensitivity to the effects of CP violation inthe neutrino sector. This sensitivity " +
+            "is currently statistically limited, butthe next generation of experiments, DUNE and Hyper-K, " +
+            "will provide an order ofmagnitude more events. To reach the full potential of these datasets " +
+            "we mustachieve a commensurate improvement in our understanding of the systematicuncertainties " +
+            "that beset them. This talk describes two proposed intermediatedetectors for the current and " +
+            "future long baseline oscillation experiments inJapan, TITUS and NuPRISM. These detectors are " +
+            "discussed in the context of thecurrent T2K oscillation analysis, highlighting the ways in which " +
+            "they couldreduce the systematic uncertainty on this measurement. The talk also describesthe " +
+            "short baseline oscillation sensitivity of NuPRISM along with the neutrinoscattering measurements " +
+            "the detector makes possible.",
+        }],
+        [{
+            'source': 'arXiv',
+            'value': "A linear polarization field on the sphere can be uniquely decomposed into anE-mode and a B-mode " +
+            "component. These two components are analytically defined interms of spin-2 spherical harmonics. " +
+            "Maps that contain filtered modes on apartial sky can also be decomposed into E-mode and B-mode " +
+            "components. However,the lack of full sky information prevents orthogonally separating thesecomponents " +
+            "using spherical harmonics. In this paper, we present a technique fordecomposing an incomplete " +
+            "map into E and B-mode components using E and Beigenmodes of the pixel covariance in the observed " +
+            "map. This method is found toorthogonally define E and B in the presence of both partial sky " +
+            "coverage andspatial filtering. This method has been applied to the BICEP2 and the KeckArray " +
+            "maps and results in reducing E to B leakage from LCDM E-modes to a levelcorresponding to a " +
+            "tensor-to-scalar ratio of $r<1\\times10^{-4}$.",
+        }],
+        [{
+            'source': 'arXiv',
+            'value': "The Planck Collaboration has recently released maps of the microwave sky inboth temperature " +
+            "and polarization. Diffuse astrophysical components (includingGalactic emissions, cosmic far " +
+            "infrared (IR) background, y-maps of the thermalSunyaev-Zeldovich (SZ) effect) and catalogs " +
+            "of many thousands of Galactic andextragalactic radio and far-IR sources, and galaxy clusters " +
+            "detected throughthe SZ effect are the main astrophysical products of the mission. A conciseoverview " +
+            "of these results and of astrophysical studies based on Planck data ispresented.",
+        }],
+        [{
+            'source': 'arXiv',
+            'value': "The correlation between active galactic nuclei (AGN) and environment providesimportant clues " +
+            "to AGN fueling and the relationship of black hole growth togalaxy evolution. In this paper, " +
+            "we analyze the fraction of galaxies inclusters hosting AGN as a function of redshift and cluster " +
+            "richness for X-raydetected AGN associated with clusters of galaxies in Dark Energy Survey " +
+            "(DES)Science Verification data. The present sample includes 33 AGN with L_X > 10^43ergs s^-1 " +
+            "in non-central, host galaxies with luminosity greater than 0.5 L*from a total sample of 432 " +
+            "clusters in the redshift range of 0.1<z<0.95.Analysis of the present sample reveals that the AGN " +
+            "fraction in red-sequencecluster members has a strong positive correlation with redshift such that " +
+            "theAGN fraction increases by a factor of ~ 8 from low to high redshift, and thefraction of cluster " +
+            "galaxies hosting AGN at high redshifts is greater than thelow-redshift fraction at 3.6 sigma. In " +
+            "particular, the AGN fraction increasessteeply at the highest redshifts in our sample at z>0.7. " +
+            "This result is in goodagreement with previous work and parallels the increase " +
+            "in star formation incluster galaxies over the same redshift range. However, the AGN fraction " +
+            "inclusters is observed to have no significant correlation with cluster mass.Future analyses " +
+            "with DES Year 1 and 2 data will be able to clarify whether AGNactivity is correlated to " +
+            "cluster mass and will tightly constrain therelationship between cluster AGN populations and " +
+            "redshift.",
+        }],
+        [{
+            'source': 'arXiv',
+            'value': "We calculate the radial profiles of galaxies where the nuclear region isself-gravitating, " +
+            "consisting of self-interacting dark matter (SIDM) with $F$degrees of freedom. For sufficiently " +
+            "high density this dark matter becomescollisional, regardless of its behaviour on galaxy " +
+            "scales. Our calculationsshow a spike in the central density profile, with properties determined " +
+            "by thedark matter microphysics, and the densities can reach the `mean density' of ablack hole " +
+            "(from dividing the black-hole mass by the volume enclosed by theSchwarzschild radius). For a " +
+            "galaxy halo of given compactness($\chi=2GM/Rc^2$), certain values for the dark matter entropy " +
+            "yield a densecentral object lacking an event horizon. For some soft equations of state ofthe " +
+            "SIDM (e.g. $F\ge6$), there are multiple horizonless solutions at givencompactness. Although " +
+            "light propagates around and through a sphere composed ofdark matter, it is gravitationally " +
+            "lensed and redshifted. While somecalculations give non-singular solutions, others yield solutions " +
+            "with a centralsingularity. In all cases the density transitions smoothly from the centralbody " +
+            "to the dark-matter envelope around it, and to the galaxy's dark matterhalo. We propose that " +
+            "pulsar timing observations will be able to distinguishbetween systems with a centrally dense " +
+            "dark matter sphere (for differentequations of state) and conventional galactic nuclei that " +
+            "harbour asupermassive black hole.",
+        }],
+        [{
+            'source': 'arXiv',
+            'value': "Upgraded electronics, improved water system dynamics, better calibration andanalysis " +
+            "techniques allowed Super-Kamiokande-IV to clearly observe verylow-energy 8B solar neutrino " +
+            "interactions, with recoil electron kineticenergies as low as 3.49 MeV. Super-Kamiokande-IV " +
+            "data-taking began in Septemberof 2008; this paper includes data until February 2014, a " +
+            "total livetime of 1664days. The measured solar neutrino flux is (2.308+-0.020(stat.) " +
+            "+0.039-0.040(syst.)) x 106/(cm2sec) assuming no oscillations. The observedrecoil electron " +
+            "energy spectrum is consistent with no distortions due toneutrino oscillations. An extended " +
+            "maximum likelihood fit to the amplitude ofthe expected solar zenith angle variation of the " +
+            "neutrino-electron elasticscattering rate in SK-IV results in a day/night asymmetry " +
+            "of(-3.6+-1.6(stat.)+-0.6(syst.))%. The SK-IV solar neutrino data determine thesolar mixing " +
+            "angle as sin2 theta_12 = 0.327+0.026-0.031, all SK solar data(SK-I, SK-II, SK III and SKIV) " +
+            "measures this angle to be sin2 theta_12 =0.334+0.027-0.023, the determined mass-squared " +
+            "splitting is Delta m2_21 =4.8+1.5-0.8 x10-5 eV2.",
+        }],
+        [{
+            'source': 'arXiv',
+            'value': "Results of exclusive photoproduction of Upsilon states in Ultraperipheralcollisions (UPC) " +
+            "of protons and ions with the CMS experiment are presented,which provides a clean probe of " +
+            "the gluon distribution at small values ofparton fractional momenta $x \\approx 10^{-2} 10^{4}$ " +
+            "at central rapidities (|y|$< 2.5$). The three Upsilon states (1S, 2S, 3S) are measured in " +
+            "the dimuondecay channel along with the photon-photon decaying to dimuon QED continuum " +
+            "at$\sqrt{s_{NN}}=5.02$~TeV for integrated luminosity of $L_{int} = 35$ nb$^{-1}$.The total " +
+            "Upsilon photoproduction cross sections at different photon-protoncenter of mass energy " +
+            "$W_{\gamma p}$ and t-differential distributions arepresented and compared with other " +
+            "experimental results as well as theoreticalpredictions.",
+        }],
+        [{
+            'source': 'arXiv',
+            'value': 'The thesis is divided into two parts. In the first part the low-energy limitof quantum ' +
+            'gravity is analysed, whereas in the second we deal with thehigh-energy domain. In the ' +
+            'first part, by applying the effective field theorypoint of view to the quantization of ' +
+            'general relativity, detectable, thoughtiny, quantum effects in the position of Newtonian ' +
+            'Lagrangian points of theEarth-Moon system are found. In order to make more realistic the ' +
+            'quantumcorrected model proposed, the full three-body problem where the Earth and theMoon ' +
+            'interact with a generic massive body and the restricted four-body probleminvolving the ' +
+            'perturbative effects produced by the gravitational presence ofthe Sun in the Earth-Moon ' +
+            'system are also studied. After that, a new quantumtheory having general relativity as its ' +
+            'classical counterpart is analysed. Byexploiting this framework, an innovative interesting ' +
+            'prediction involving theposition of Lagrangian points within the context of general relativity ' +
+            'isdescribed. Furthermore, the new pattern provides quantum corrections to therelativistic ' +
+            'coordinates of Earth-Moon libration points of the order of fewmillimetres. The second part ' +
+            'of the thesis deals with the Riemannian curvaturecharacterizing the boosted form assumed by ' +
+            'the Schwarzschild-de Sitter metric.The analysis of the Kretschmann invariant and the geodesic ' +
+            'equation shows thatthe spacetime possesses a "scalar curvature singularity" within a 3-sphere ' +
+            'andthat it is possible to define what we here call "boosted horizon", a sort ofelastic wall ' + 
+            'where all particles are surprisingly pushed away, suggesting thatsuch "boosted geometries" ' +
+            'are ruled by a sort of "antigravity effect".Eventually, the equivalence with the coordinate ' +
+            'shift method is invoked inorder to demonstrate that all $\delta^2$ terms appearing in the ' +
+            'Riemanncurvature tensor give vanishing contribution in distributional sense.',
+        }],
+        [{
+            'source': 'arXiv',
+            'value': "Results of a search for the pair production of photon-jets---collimated groupings of " +
+            "photons---in the ATLAS detector at the Large Hadron Collider are reported. Highly collimated " +
+            "photon-jets can arise from the decay of new, highly boosted particles that can decay to " +
+            "multiple photons collimated enough to be identified in the electromagnetic calorimeter as " +
+            "a single, photon-like energy cluster. Data from proton--proton collisions at a center-of-mass " +
+            "energy of 13 TeV, corresponding to an integrated luminosity of 36.7 fb$^{-1}$, were collected " +
+            "in 2015 and 2016. Candidate photon-jet pair production events are selected from those containing " +
+            "two reconstructed photons using a set of identification criteria much less stringent than " +
+            "that typically used for the selection of photons, with additional criteria applied to provide " +
+            "improved sensitivity to photon-jets. Narrow excesses in the reconstructed diphoton mass " +
+            "spectra are searched for. The observed mass spectra are consistent with the Standard Model " +
+            "background expectation. The results are interpreted in the context of a model containing a " +
+            "new, high-mass scalar particle with narrow width, $X$, that decays into pairs of photon-jets " +
+            "via new, light particles, $a$. Upper limits are placed on the cross-section times the product " +
+            "of branching ratios $\sigma \\times \mathcal{B}(X \\rightarrow aa) \\times \mathcal {B}(a " +
+            "\\rightarrow \gamma \gamma)^{2}$ for 200 GeV $< m_{X} <$ 2 TeV and for ranges of $ m_a $ " +
+            "from a lower mass of 100 MeV up to between 2 GeV and 10 GeV, depending upon $ m_X $. Upper " +
+            "limits are also placed on $\sigma \\times \mathcal{B}(X \\rightarrow aa) \\times \mathcal " +
+            "{B}(a \\rightarrow 3\pi^{0})^{2}$ for the same range of $ m_X $ and for ranges of $ m_a $ " +
+            "from a lower mass of 500 MeV up to between 2 GeV and 10 GeV.",
+        }],
+    ]
+    for abstract, record in zip(abstracts, many_results):
+        assert record.get('abstracts') == abstract


### PR DESCRIPTION
The presence of ``<`` and ``>`` in abstracts was generating problems in the processing of records from arXiv, such as truncating them or removing middle parts of it.

The problem was generated in not only one, but two steps of the process, so I propose here a solution in which we convert those two symbols to different tokens that will very likely not appear in an abstract, and then turn them back to their original value.

Signed-off-by: Victor Balbuena <vbalbp@gmail.com>