### PR TITLE
tests: python2/3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of hepcrawl.
-# Copyright (C) 2015, 2016, 2017 CERN.
+# Copyright (C) 2015, 2016, 2017, 2019 CERN.
 #
 # hepcrawl is a free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for
@@ -15,7 +15,7 @@ services:
   - docker
 
 python:
-  - '2.7'
+  - "2.7"
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,6 @@ env:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - env: PYTHON=py3 SUITE=unit
 
 before_install:
   - travis_retry pip install twine wheel coveralls check-manifest

--- a/docker-compose.test.py3.yml
+++ b/docker-compose.test.py3.yml
@@ -66,7 +66,7 @@ services:
 
   unit:
     <<: *service_base
-    command: bash -c "py.test tests/unit -vv && make -C docs clean && make -C docs html && python setup.py sdist && ls dist/*"
+    command: py.test -vv tests/unit
     links: []
 
   celery:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,17 +31,9 @@ from autosemver.packaging import (
     get_releasenotes,
 )
 
-_warn_node_old = sphinx.environment.BuildEnvironment.warn_node
 URL = 'http://github.com/inspirehep/hepcrawl'
 BUGTRACKER_URL = URL + '/issues/'
-
-
-def _warn_node(self, msg, *args, **kwargs):
-    """Do not warn on external images."""
-    if not msg.startswith('nonlocal image URI found:'):
-        _warn_node_old(self, msg, *args, **kwargs)
-
-
+suppress_warnings = ['image.nonlocal_uri']
 
 
 if not os.path.exists('_build/html/_static'):
@@ -63,10 +55,6 @@ with open('_build/html/_static/CHANGELOG.txt', 'w') as changelog_fd:
         bugtracker_url=BUGTRACKER_URL,
     ).encode('utf-8'))
 
-
-
-
-sphinx.environment.BuildEnvironment.warn_node = _warn_node
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,6 +1,6 @@
 ..
     This file is part of hepcrawl.
-    Copyright (C) 2015, 2016, 2017 CERN.
+    Copyright (C) 2015, 2016, 2017, 2019 CERN.
 
     hepcrawl is a free software; you can redistribute it and/or modify it
     under the terms of the Revised BSD License; see LICENSE file for
@@ -230,13 +230,14 @@ Then we add our input processor to the ``HEPLoader``:
 .. code-block:: python
 
     from scrapy.loader.processors import MapCompose
+    from six import text_type
     from .inputs import convert_html_subscripts_to_latex
 
     class HEPLoader(ItemLoader):
 
         abstract_in = MapCompose(
             convert_html_subscripts_to_latex,
-            unicode.strip,
+            text_type.strip,
         )
 
 
@@ -268,13 +269,14 @@ in the items. For example, instead of a list only assign the first value in the 
 .. code-block:: python
 
     from scrapy.loader.processors import MapCompose, TakeFirst
+    from six import text_type
     from .inputs import convert_html_subscripts_to_latex
 
     class HEPLoader(ItemLoader):
 
         abstract_in = MapCompose(
             convert_html_subscripts_to_latex,
-            unicode.strip,
+            text_type.strip,
         )
         abstract_out = TakeFirst()
 

--- a/hepcrawl/loaders.py
+++ b/hepcrawl/loaders.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of hepcrawl.
-# Copyright (C) 2015, 2016, 2017 CERN.
+# Copyright (C) 2015, 2016, 2017, 2019 CERN.
 #
 # hepcrawl is a free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for
@@ -18,6 +18,8 @@ from __future__ import absolute_import, division, print_function
 from scrapy.loader import ItemLoader
 from scrapy.loader.processors import Join, MapCompose, TakeFirst
 from scrapy.utils.url import canonicalize_url
+
+from six import text_type
 
 from .inputs import (
     selective_remove_tags,
@@ -79,7 +81,7 @@ class HEPLoader(ItemLoader):
         convert_html_subscripts_to_latex,
         remove_attributes_from_tags,
         selective_remove_tags(keep=MATHML_ELEMENTS),
-        unicode.strip,
+        text_type.strip,
     )
 
     abstract_out = TakeFirst()
@@ -96,7 +98,7 @@ class HEPLoader(ItemLoader):
         convert_html_subscripts_to_latex,
         remove_attributes_from_tags,
         selective_remove_tags(keep=MATHML_ELEMENTS),
-        unicode.strip,
+        text_type.strip,
     )
 
     subtitle_in = MapCompose(
@@ -104,7 +106,7 @@ class HEPLoader(ItemLoader):
         convert_html_subscripts_to_latex,
         remove_attributes_from_tags,
         selective_remove_tags(keep=MATHML_ELEMENTS),
-        unicode.strip,
+        text_type.strip,
     )
 
     subtitle_out = TakeFirst()

--- a/hepcrawl/spiders/common/lastrunstore_spider.py
+++ b/hepcrawl/spiders/common/lastrunstore_spider.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of hepcrawl.
-# Copyright (C) 2017 CERN.
+# Copyright (C) 2017, 2019 CERN.
 #
 # hepcrawl is a free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for
@@ -60,7 +60,7 @@ class LastRunStoreSpider(StatefulSpider):
             string: path to last runs path
         """
         lasts_run_path = self.settings['LAST_RUNS_PATH']
-        file_name = hashlib.sha1(self.make_file_fingerprint(set_)).hexdigest() + '.json'
+        file_name = hashlib.sha1(self.make_file_fingerprint(set_).encode('utf-8')).hexdigest() + '.json'
         return path.join(lasts_run_path, self.name, file_name)
 
     def _load_last_run(self, set_):

--- a/hepcrawl/spiders/common/oaipmh_spider.py
+++ b/hepcrawl/spiders/common/oaipmh_spider.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of hepcrawl.
-# Copyright (C) 2017 CERN.
+# Copyright (C) 2017, 2019 CERN.
 #
 # hepcrawl is a free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for

--- a/hepcrawl/spiders/desy_spider.py
+++ b/hepcrawl/spiders/desy_spider.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of hepcrawl.
-# Copyright (C) 2017 CERN.
+# Copyright (C) 2017, 2019 CERN.
 #
 # hepcrawl is a free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for
@@ -17,13 +17,14 @@ from flask.app import Flask
 from inspire_dojson import marcxml2record
 from lxml import etree
 from scrapy import Request
+
 from six.moves import urllib
 
 from . import StatefulSpider
 from ..utils import (
-    ftp_list_files,
-    ftp_connection_info,
     ParsedItem,
+    ftp_connection_info,
+    ftp_list_files,
     strict_kwargs,
 )
 

--- a/hepcrawl/spiders/pos_spider.py
+++ b/hepcrawl/spiders/pos_spider.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of hepcrawl.
-# Copyright (C) 2016, 2017 CERN.
+# Copyright (C) 2016, 2017, 2019 CERN.
 #
 # hepcrawl is a free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for
@@ -11,21 +11,21 @@
 
 from __future__ import absolute_import, division, print_function
 
-import re
 import os
-from urlparse import urljoin
-from six.moves.urllib.parse import quote
+import re
 
 from scrapy import Request, Selector
+
+from six.moves.urllib.parse import quote, urljoin
 
 from . import StatefulSpider
 from ..dateutils import create_valid_date
 from ..items import HEPRecord
 from ..loaders import HEPLoader
 from ..utils import (
-    get_licenses,
-    get_first,
     ParsedItem,
+    get_first,
+    get_licenses,
     strict_kwargs,
 )
 

--- a/hepcrawl/spiders/wsp_spider.py
+++ b/hepcrawl/spiders/wsp_spider.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of hepcrawl.
-# Copyright (C) 2015, 2016, 2017 CERN.
+# Copyright (C) 2015, 2016, 2017, 2019 CERN.
 #
 # hepcrawl is a free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for
@@ -12,21 +12,22 @@
 from __future__ import absolute_import, division, print_function
 
 import os
-import urlparse
 import tempfile
 
 from scrapy import Request
 from scrapy.spiders import XMLFeedSpider
 
+from six.moves.urllib.parse import urlsplit
+
 from . import StatefulSpider
 from ..parsers import JatsParser
 from ..utils import (
-    ftp_list_files,
-    ftp_connection_info,
-    local_list_files,
-    unzip_xml_files,
     ParsedItem,
+    ftp_connection_info,
+    ftp_list_files,
+    local_list_files,
     strict_kwargs,
+    unzip_xml_files,
 )
 
 
@@ -212,7 +213,7 @@ class WorldScientificSpider(StatefulSpider, XMLFeedSpider):
     def handle_package_file(self, response):
         """Handle a local zip package and yield every XML."""
         self.logger.info("Visited file %s" % response.url)
-        zip_filepath = urlparse.urlsplit(response.url).path
+        zip_filepath = urlsplit(response.url).path
         xml_files = unzip_xml_files(zip_filepath, self.destination_folder)
 
         for xml_file in xml_files:

--- a/hepcrawl/testlib/utils.py
+++ b/hepcrawl/testlib/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of hepcrawl.
-# Copyright (C) 2017 CERN.
+# Copyright (C) 2017, 2019 CERN.
 #
 # hepcrawl is a free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for
@@ -29,7 +29,7 @@ def get_crawler_instance(crawler_host, *args, **kwargs):
 
 
 def deep_sort(element):
-    """Dummy deep-sort json dicts (lists, dicts, stirngs, bools and integers)."""
+    """Dummy deep-sort json dicts (lists, dicts, strings, bools and integers)."""
     if isinstance(element, dict):
         for key, value in element.items():
             element[key] = deep_sort(value)

--- a/hepcrawl/utils.py
+++ b/hepcrawl/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of hepcrawl.
-# Copyright (C) 2015, 2016, 2017, 2018 CERN.
+# Copyright (C) 2015, 2016, 2017, 2018, 2019 CERN.
 #
 # hepcrawl is a free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for
@@ -20,16 +20,16 @@ from operator import itemgetter
 from itertools import groupby
 from netrc import netrc
 from zipfile import ZipFile
-from urlparse import urlparse
 
 import ftputil
 import ftputil.session
 import ftplib
-from hepcrawl.tohep import hep_to_hep, _normalize_hepcrawl_record, \
-    hepcrawl_to_hep, UnknownItemFormat
 from inspire_schemas.builders import LiteratureBuilder
-
 from scrapy import Selector
+
+from hepcrawl.tohep import (hep_to_hep, _normalize_hepcrawl_record,
+                            hepcrawl_to_hep, UnknownItemFormat)
+from six.moves.urllib.parse import urlparse
 
 RE_FOR_THE = re.compile(
     r'\b(?:for|on behalf of|representing)\b',
@@ -238,9 +238,9 @@ def range_as_string(data):
     ranges = []
     for key, group in groupby(
         enumerate(data),
-        lambda (index, item): index - item
+        lambda index_item: index_item[0] - index_item[1]
     ):
-        group = map(itemgetter(1), group)
+        group = [year for _, year in group]
         if len(group) > 1:
             rangestring = "{}-{}".format(str(group[0]), str(group[-1]))
             ranges.append(rangestring)
@@ -289,7 +289,7 @@ def get_journal_and_section(publication):
     journal_title = ''
     possible_sections = ["A", "B", "C", "D", "E"]
     try:
-        split_pub = filter(None, re.split(r'(\W+)', publication))
+        split_pub = [element for element in re.split(r'(\W+)', publication) if element]
         if split_pub[-1] in possible_sections:
             section = split_pub.pop(-1)
         journal_title = "".join(

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of hepcrawl.
-# Copyright (C) 2015, 2016, 2017, 2018 CERN.
+# Copyright (C) 2015, 2016, 2017, 2018, 2019 CERN.
 #
 # hepcrawl is a free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for
@@ -44,6 +44,7 @@ install_requires = [
 tests_require = [
     'check-manifest>=0.25',
     'coverage>=4.0',
+    'deepdiff==3.3.0',
     'freezegun>=0.3.9',
     'isort==4.2.2',
     'mock~=2.0,>=2.0.0',
@@ -57,7 +58,7 @@ tests_require = [
 
 extras_require = {
     'docs': [
-        'Sphinx>=1.4',
+        'Sphinx~=1.0,>=1.5',
         'sphinxcontrib-napoleon>=0.6.1',
     ],
     'tests': tests_require,

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,8 @@ install_requires = [
     'python-scrapyd-api>=2.0.1',
     'harvestingkit>=0.6.12',
     'Sickle~=0.6,>=0.6.2',
+    # newer versions seem incompatible with required scrapyd version
+    'Twisted~=18.0,>=18.9.0',
 ]
 
 tests_require = [

--- a/tests/functional/arxiv/test_arxiv.py
+++ b/tests/functional/arxiv/test_arxiv.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of hepcrawl.
-# Copyright (C) 2017 CERN.
+# Copyright (C) 2017, 2019 CERN.
 #
 # hepcrawl is a free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for
@@ -14,13 +14,14 @@ from __future__ import absolute_import, division, print_function
 import os
 import pytest
 
+from deepdiff import DeepDiff
 from hepcrawl.testlib.celery_monitor import CeleryMonitor
 from hepcrawl.testlib.fixtures import (
     expected_json_results_from_file,
     clean_dir,
 )
 from hepcrawl.testlib.tasks import app as celery_app
-from hepcrawl.testlib.utils import get_crawler_instance, deep_sort
+from hepcrawl.testlib.utils import get_crawler_instance
 
 
 @pytest.fixture(scope='function', autouse=True)
@@ -122,8 +123,5 @@ def test_arxiv(
         override_generated_fields(expected) for expected in expected_results
     ]
 
-    gotten_results = deep_sort(gotten_results)
-    expected_results = deep_sort(expected_results)
-
-    assert gotten_results == expected_results
+    assert DeepDiff(gotten_results, expected_results, ignore_order=True) == {}
     assert not crawl_result['errors']

--- a/tests/functional/cds/test_cds.py
+++ b/tests/functional/cds/test_cds.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of hepcrawl.
-# Copyright (C) 2017 CERN.
+# Copyright (C) 2017, 2019 CERN.
 #
 # hepcrawl is a free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for
@@ -14,9 +14,10 @@ from __future__ import absolute_import, division, print_function
 import os
 import pytest
 
+from deepdiff import DeepDiff
 from hepcrawl.testlib.tasks import app as celery_app
 from hepcrawl.testlib.celery_monitor import CeleryMonitor
-from hepcrawl.testlib.utils import get_crawler_instance, deep_sort
+from hepcrawl.testlib.utils import get_crawler_instance
 from hepcrawl.testlib.fixtures import (
     get_test_suite_path,
     expected_json_results_from_file,
@@ -123,8 +124,5 @@ def test_cds(
         override_generated_fields(expected) for expected in expected_results
     ]
 
-    gotten_results = deep_sort(gotten_results)
-    expected_results = deep_sort(expected_results)
-
-    assert gotten_results == expected_results
+    assert DeepDiff(gotten_results, expected_results, ignore_order=True) == {}
     assert not crawl_result['errors']

--- a/tests/functional/desy/test_desy.py
+++ b/tests/functional/desy/test_desy.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of hepcrawl.
-# Copyright (C) 2017 CERN.
+# Copyright (C) 2017, 2019 CERN.
 #
 # hepcrawl is a free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for
@@ -18,6 +18,7 @@ from time import sleep
 
 import pytest
 
+from deepdiff import DeepDiff
 from hepcrawl.testlib.celery_monitor import CeleryMonitor
 from hepcrawl.testlib.fixtures import (
     get_test_suite_path,
@@ -25,7 +26,7 @@ from hepcrawl.testlib.fixtures import (
     clean_dir,
 )
 from hepcrawl.testlib.tasks import app as celery_app
-from hepcrawl.testlib.utils import get_crawler_instance, deep_sort
+from hepcrawl.testlib.utils import get_crawler_instance
 
 
 def override_dynamic_fields_on_records(records):
@@ -202,20 +203,16 @@ def test_desy(
     gotten_records = override_dynamic_fields_on_records(gotten_records)
     expected_results = override_dynamic_fields_on_records(expected_results)
 
-    gotten_records = deep_sort(
-        sorted(
+    gotten_records = sorted(
             gotten_records,
             key=lambda record: record['titles'][0]['title'],
         )
-    )
-    expected_results = deep_sort(
-        sorted(
+    expected_results = sorted(
             expected_results,
             key=lambda result: result['titles'][0]['title'],
         )
-    )
 
-    assert gotten_records == expected_results
+    assert DeepDiff(gotten_records, expected_results, ignore_order=True) == {}
     assert not crawl_result['errors']
 
 
@@ -293,20 +290,16 @@ def test_desy_crawl_twice(expected_results, settings, cleanup):
     gotten_records = override_dynamic_fields_on_records(gotten_records)
     expected_results = override_dynamic_fields_on_records(expected_results)
 
-    gotten_records = deep_sort(
-        sorted(
+    gotten_records = sorted(
             gotten_records,
             key=lambda record: record['titles'][0]['title'],
         )
-    )
-    expected_results = deep_sort(
-        sorted(
+    expected_results = sorted(
             expected_results,
             key=lambda result: result['titles'][0]['title'],
         )
-    )
 
-    assert gotten_records == expected_results
+    assert DeepDiff(gotten_records, expected_results, ignore_order=True) == {}
     assert not crawl_result['errors']
 
     # Second crawl

--- a/tests/unit/test_edp.py
+++ b/tests/unit/test_edp.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of hepcrawl.
-# Copyright (C) 2015, 2016, 2017 CERN.
+# Copyright (C) 2015, 2016, 2017, 2019 CERN.
 #
 # hepcrawl is a free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for
@@ -10,11 +10,9 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
-
-import six
-
 import pkg_resources
 import pytest
+import six
 
 from hepcrawl.spiders import edp_spider
 from hepcrawl.items import HEPRecord
@@ -57,7 +55,7 @@ def package_jats(targzfile):
     """Extract tar.gz package with JATS XML file."""
     spider = edp_spider.EDPSpider()
     response = fake_response_from_string(text="", url="file://" + targzfile)
-    return spider.handle_package_file(response).next()
+    return next(spider.handle_package_file(response))
 
 
 @pytest.fixture
@@ -100,7 +98,7 @@ def package_rich(tarbzfile):
     """Extract tar.gz package with 'rich' XML file."""
     spider = edp_spider.EDPSpider()
     response = fake_response_from_string(text="", url="file://" + tarbzfile)
-    return spider.handle_package_file(response).next()
+    return next(spider.handle_package_file(response))
 
 @pytest.fixture
 def record_rich(package_rich):
@@ -359,7 +357,7 @@ def test_handle_package_ftp(tarbzfile):
     """Test getting the target folder name for xml files."""
     spider = edp_spider.EDPSpider()
     response = fake_response_from_string(text=tarbzfile)
-    request = spider.handle_package_ftp(response).next()
+    request = next(spider.handle_package_ftp(response))
 
     assert isinstance(request, Request)
     assert request.meta["source_folder"] == tarbzfile

--- a/tests/unit/test_parsers_jats.py
+++ b/tests/unit/test_parsers_jats.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of hepcrawl.
-# Copyright (C) 2015, 2016, 2017 CERN.
+# Copyright (C) 2015, 2016, 2017, 2019 CERN.
 #
 # hepcrawl is a free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for
@@ -16,7 +16,9 @@ from __future__ import (
 
 import pytest
 import yaml
+import sys
 
+from deepdiff import DeepDiff
 from inspire_schemas.utils import validate
 from hepcrawl.testlib.fixtures import get_test_suite_path
 from hepcrawl.parsers.jats import JatsParser
@@ -96,7 +98,13 @@ def test_field(field_name, records):
     result = getattr(records['jats'], field_name)
     expected = records['expected'][field_name]
 
-    assert result == expected
+    if field_name == 'authors':
+        diffs = DeepDiff(result, expected, ignore_order=True)
+        if sys.version_info[0] < 3 and 'type_changes' in diffs:
+            del diffs['type_changes']
+        assert diffs == {}
+    else:
+        assert result == expected
 
 
 def test_publication_date(records):

--- a/tests/unit/test_pipelines.py
+++ b/tests/unit/test_pipelines.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of hepcrawl.
-# Copyright (C) 2016, 2017 CERN.
+# Copyright (C) 2016, 2017, 2019 CERN.
 #
 # hepcrawl is a free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for
@@ -16,7 +16,7 @@ import os
 
 import pytest
 
-from scrapy.spiders import Spider
+from scrapy import Spider
 from inspire_schemas.api import validate
 
 from hepcrawl.spiders import arxiv_spider
@@ -48,7 +48,7 @@ def json_spider_record(tmpdir):
 
     test_selectors = fake_response.xpath('.//record')
     items = (spider.parse_record(sel) for sel in test_selectors)
-    parsed_record = items.next()
+    parsed_record = next(items)
     assert parsed_record
     yield spider, parsed_record
 

--- a/tests/unit/test_pos.py
+++ b/tests/unit/test_pos.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of hepcrawl.
-# Copyright (C) 2015, 2016, 2017 CERN.
+# Copyright (C) 2015, 2016, 2017, 2019 CERN.
 #
 # hepcrawl is a free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for
@@ -11,8 +11,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import pkg_resources
-
 import pytest
+
 from scrapy.crawler import Crawler
 from scrapy.http import HtmlResponse
 
@@ -53,11 +53,11 @@ def generated_conference_paper(scrape_pos_conference_paper_page_body):
 
     crawler = Crawler(spidercls=pos_spider.POSSpider)
     spider = pos_spider.POSSpider.from_crawler(crawler)
-    request = spider.parse(
+    request = next(spider.parse(
         fake_response_from_file(
             file_name=str('pos/sample_pos_record.xml'),
         )
-    ).next()
+    ))
     response = HtmlResponse(
         url=request.url,
         request=request,
@@ -68,7 +68,7 @@ def generated_conference_paper(scrape_pos_conference_paper_page_body):
 
     pipeline = InspireCeleryPushPipeline()
     pipeline.open_spider(spider)
-    parsed_item = request.callback(response).next()
+    parsed_item = next(request.callback(response))
     crawl_result = pipeline.process_item(parsed_item, spider)
     assert crawl_result['record']
 

--- a/tests/unit/test_testlib_utils.py
+++ b/tests/unit/test_testlib_utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of hepcrawl.
-# Copyright (C) 2015, 2016, 2017 CERN.
+# Copyright (C) 2015, 2016, 2017, 2019 CERN.
 #
 # hepcrawl is a free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for
@@ -9,18 +9,17 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from hepcrawl.testlib.utils import deep_sort
+from deepdiff import DeepDiff
 
 
-def test_deep_sort_with_dict_in_list():
+def test_deepdiff_with_dict_in_list():
     element = [{'b': {'name': 'bb'}}, {'a': {'name': 'aa'}}]
     expected_element = [{'a': {'name': 'aa'}}, {'b': {'name': 'bb'}}]
 
-    result = deep_sort(expected_element)
-    assert result == expected_element
+    assert DeepDiff(expected_element, element, ignore_order=True) == {}
 
 
-def test_deep_sort_with_query_parser_output():
+def test_deepdiff_with_query_parser_output():
     element = {
         "bool": {
             "filter": {
@@ -73,5 +72,4 @@ def test_deep_sort_with_query_parser_output():
         }
     }
 
-    result = deep_sort(expected_element)
-    assert result == expected_element
+    assert DeepDiff(expected_element, element, ignore_order=True) == {}

--- a/tests/unit/test_world_scientific.py
+++ b/tests/unit/test_world_scientific.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of hepcrawl.
-# Copyright (C) 2015, 2016, 2017 CERN.
+# Copyright (C) 2015, 2016, 2017, 2019 CERN.
 #
 # hepcrawl is a free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for
@@ -14,8 +14,8 @@ from __future__ import (
     unicode_literals,
 )
 
-import pytest
 import os
+import pytest
 
 from scrapy.crawler import Crawler
 from scrapy.http import TextResponse
@@ -66,7 +66,7 @@ def get_records(response_file_name):
 
 def get_one_record(response_file_name):
     records = get_records(response_file_name)
-    record = records.next()
+    record = next(records)
     assert record
 
     return record


### PR DESCRIPTION
    * ensure tests pass under python2 and python3

    * use deepdiff for comparing nested data-structures

    * remove deep_sort, because sorting a list of dicts
      is not supported in python3

    * accommodate differences in str types between python 2/3

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

improve compatibility with python3 by using six
update tests so that all existing unit tests pass with both python 2.7 and python 3.7

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
