### PR TITLE
hepcrawl: removing unused imports from arXiv_spider

### DIFF
--- a/hepcrawl/spiders/arxiv_spider.py
+++ b/hepcrawl/spiders/arxiv_spider.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of hepcrawl.
-# Copyright (C) 2016, 2017 CERN.
+# Copyright (C) 2016, 2017, 2019 CERN.
 #
 # hepcrawl is a free software; you can redistribute it and/or modify it
 # under the terms of the Revised BSD License; see LICENSE file for
@@ -11,17 +11,10 @@
 
 from __future__ import absolute_import, division, print_function
 
-import re
-
 from hepcrawl.spiders.common.oaipmh_spider import OAIPMHSpider
-from scrapy import Selector
-from six.moves import zip_longest
 
 from ..parsers import ArxivParser
 from ..utils import (
-    coll_cleanforthe,
-    get_licenses,
-    split_fullname,
     ParsedItem,
     strict_kwargs,
 )
@@ -41,13 +34,13 @@ class ArxivSpider(OAIPMHSpider):
 
     @strict_kwargs
     def __init__(
-        self,
-        url='http://export.arxiv.org/oai2',
-        format='arXiv',
-        sets=None,
-        from_date=None,
-        until_date=None,
-        **kwargs
+            self,
+            url='http://export.arxiv.org/oai2',
+            format='arXiv',
+            sets=None,
+            from_date=None,
+            until_date=None,
+            **kwargs
     ):
         super(ArxivSpider, self).__init__(
             url=url,
@@ -86,11 +79,11 @@ class ArxivSpiderSingle(OAIPMHSpider):
 
     @strict_kwargs
     def __init__(
-        self,
-        url='http://export.arxiv.org/oai2',
-        format='arXiv',
-        identifier=None,
-        **kwargs
+            self,
+            url='http://export.arxiv.org/oai2',
+            format='arXiv',
+            identifier=None,
+            **kwargs
     ):
         super(ArxivSpiderSingle, self).__init__(
             url=url,


### PR DESCRIPTION
    * remove unused imports in spider now split off into parser
      hepcrawl/parsers/arxiv.py

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

Code cleanup. Removes leftover unused imports. No functional changes. 

## Description
<!--- Describe your changes in detail -->

Code cleanup. Removes leftover unused imports. No functional changes. 

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
