### PR TITLE
travis: fix deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,4 +74,4 @@ deploy:
       python: 2.7
       distributions: sdist
       repo: inspirehep/hepcrawl
-      condition: env(SUITE) = functional_arxiv AND env(PYTHON) = py2
+      condition: $SUITE = functional_arxiv && $PYTHON = py2


### PR DESCRIPTION
Confusingly enough, the condition to deploy in `deploy.on.condition`
uses a bash condition (see
https://docs.travis-ci.com/user/deployment#conditional-releases-with-on
) and not a travis condition as in
https://docs.travis-ci.com/user/conditions-v1.