### PR TITLE
Add a configuration for local deployments

### DIFF
--- a/hepcrawl/scrapy.cfg
+++ b/hepcrawl/scrapy.cfg
@@ -18,3 +18,7 @@ url = http://scrapyd:6800/
 project = hepcrawl
 #username = scrapy
 #password = secret
+
+[deploy:local]
+url = http://localhost:6800/
+project = hepcrawl


### PR DESCRIPTION
Add a local config for scrapyd

## Description
Instead of replacing the url of scrapyd when running it locally, the configuration file allows to specify multiple configurations. This way scrapyd client can be called as `scrapyd-deploy local -p hepcrawl`