### PR TITLE
setup: Downgrade minimal celery version to 4.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ install_requires = [
     'scrapyd-client>=1.0.1',
     'six>=1.9.0',
     'requests~=2.22,>=2.22.0',
-    'celery~=4.2',
+    'celery>=4.1',
     'redis>=2.10.5',
     'pyasn1>=0.1.8',  # Needed for dependency resolving.
     'LinkHeader>=0.4.3',

--- a/tests/Dockerfile.hepcrawl_base
+++ b/tests/Dockerfile.hepcrawl_base
@@ -7,7 +7,7 @@
 # under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 
-FROM centos
+FROM centos:7
 
 RUN yum install -y epel-release && \
     yum update -y && \


### PR DESCRIPTION
* Downgrade minimum version of celery to 4.1 as 4.2 is not supported by inspire-next
