### PR TITLE
Fix APS spider - document url header

### DIFF
--- a/hepcrawl/pipelines.py
+++ b/hepcrawl/pipelines.py
@@ -56,6 +56,7 @@ class DocumentsPipeline(FilesPipeline):
         )
 
     def get_media_requests(self, item, info):
+        LOGGER.info("item: :", item)
         if item.get('file_urls'):
             LOGGER.info(
                 'Got the following files to download:\n%s', pprint.pformat(
@@ -63,9 +64,9 @@ class DocumentsPipeline(FilesPipeline):
                 )
             )
             return [Request(x) for x in item.get(self.files_urls_field, [])]
-        return list()
+        return item.get("file_requests", [])
 
-    def generate_presigned_s3_url(self, path, expire=86400):
+    def generate_presigned_s3_url(self, path, expire=7776000):
         bucket_location = get_project_settings().get("DOWNLOAD_BUCKET", "documents")
         LOGGER.info("Generating presigned url for: %s in %s", path, bucket_location)
         return self.store.s3_client.generate_presigned_url(

--- a/hepcrawl/spiders/aps_spider.py
+++ b/hepcrawl/spiders/aps_spider.py
@@ -123,11 +123,11 @@ class APSSpider(LastRunStoreSpider):
         file_name = self._file_name_from_url(response.url)
         parser.attach_fulltext_document(file_name, response.url)
         record = parser.parse()
-        file_urls = [document['url'] for document in record.get('documents', [])]
+        file_requests = [Request(url=document['url'], headers={'Accept': 'text/xml'}) for document in record.get('documents', [])]
         return ParsedItem(
             record=record,
             record_format='hep',
-            file_urls=file_urls
+            file_requests=file_requests
         )
 
     def _parse_json_on_failure(self, failure):

--- a/hepcrawl/spiders/elsevier_spider.py
+++ b/hepcrawl/spiders/elsevier_spider.py
@@ -231,12 +231,12 @@ class ElsevierSpider(StatefulSpider):
             )
             parser.attach_fulltext_document(file_name, document_url)
             parsed_record = parser.parse()
-            files_urls = [
-                document["url"] for document in parsed_record.get("documents", [])
+            file_urls = [
+                document['url'] for document in parsed_record.get('documents', [])
             ]
-            self.logger.info("Files to download: %s", files_urls)
+            self.logger.info("Files to download: %s", file_urls)
             return ParsedItem(
-                record=parsed_record, file_urls=files_urls, record_format="hep"
+                record=parsed_record, file_urls=file_urls, record_format="hep"
             )
         else:
             self.logger.info(

--- a/hepcrawl/utils.py
+++ b/hepcrawl/utils.py
@@ -434,6 +434,9 @@ class ParsedItem(dict):
         file_urls(list(str)): URLs to the files to be downloaded by
             ``DocumentsPipeline``.
 
+        file_requests(list(Request)): Request objects of files to be downloaded
+            by ``DocumentsPipeline``
+
         ftp_params(dict): Parameter for the
             :class:`hepcrawl.pipelines.DocumentsPipeline` to be able to connect
             to the ftp server, if any.
@@ -441,6 +444,7 @@ class ParsedItem(dict):
         record_files(list(RecordFile)): files attached to the record, usually
             populated by :class:`hepcrawl.pipelines.DocumentsPipeline` from the
             ``file_urls`` parameter.
+
 
         source_file(str): name of the crawled file.
 
@@ -453,6 +457,7 @@ class ParsedItem(dict):
         record,
         record_format,
         file_urls=None,
+        file_requests=None,
         ftp_params=None,
         record_files=None,
         file_name=None,
@@ -461,6 +466,7 @@ class ParsedItem(dict):
             record=record,
             record_format=record_format,
             file_urls=file_urls,
+            file_requests=file_requests,
             ftp_params=ftp_params,
             record_files=record_files,
             file_name=file_name,


### PR DESCRIPTION
APS XML document requires `Accept: text/xml` header to properly download XML file.