### PR TITLE
parsers: escape latex in archive parser

### DIFF
--- a/hepcrawl/parsers/arxiv.py
+++ b/hepcrawl/parsers/arxiv.py
@@ -19,6 +19,7 @@ from inspire_schemas.api import LiteratureBuilder
 from inspire_schemas.utils import classify_field
 from inspire_utils.dedupers import dedupe_list
 from inspire_utils.helpers import maybe_int
+from pylatexenc.latex2text import LatexNodes2Text
 
 from ..mappings import CONFERENCE_WORDS, THESIS_WORDS
 from ..utils import coll_cleanforthe, get_node, split_fullname
@@ -210,8 +211,8 @@ class ArxivParser(object):
     @property
     def abstract(self):
         abstract = self.root.xpath('.//abstract/text()').extract_first()
-
-        return self.fix_long_text(abstract)
+        long_text_fixed = self.fix_long_text(abstract)
+        return self.escape_latex_to_unicode(long_text_fixed)
 
     @property
     def authors(self):
@@ -272,7 +273,8 @@ class ArxivParser(object):
 
     @property
     def title(self):
-        return self.fix_long_text(self.root.xpath('.//title/text()').extract_first())
+        long_text_fixed = self.fix_long_text(self.root.xpath('.//title/text()').extract_first())
+        return self.escape_latex_to_unicode(long_text_fixed)
 
     @staticmethod
     def fix_long_text(text):
@@ -352,3 +354,8 @@ class ArxivParser(object):
         if not hasattr(self, '_authors_and_collaborations'):
             self._authors_and_collaborations = self._get_authors_and_collaborations(self.root)
         return self._authors_and_collaborations
+
+    @staticmethod
+    def escape_latex_to_unicode(latex_string):
+        l2t = LatexNodes2Text(math_mode="verbatim")
+        return l2t.latex_to_text(latex_string)

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,8 @@ install_requires = [
     'Sickle~=0.6,>=0.6.2',
     # newer versions seem incompatible with required scrapyd version
     'Twisted~=18.0,>=18.9.0',
+    #latex parsing
+    'pylatexenc~=2.9',
 ]
 
 tests_require = [

--- a/tests/unit/responses/arxiv/sample_arxiv_record0.xml
+++ b/tests/unit/responses/arxiv/sample_arxiv_record0.xml
@@ -29,7 +29,7 @@
 <forenames>Heng</forenames>
 </author>
 </authors>
-<title>Irreversible degradation of quantum coherence under relativistic motion</title>
+<title>$L^2$ vanishing theorem on some K\"{a}hler manifolds</title>
 <categories>quant-ph gr-qc hep-th</categories>
 <comments>6 pages, 4 figures, conference paper</comments>
 <report-no>YITP-2016-26</report-no>

--- a/tests/unit/test_arxiv_single.py
+++ b/tests/unit/test_arxiv_single.py
@@ -80,10 +80,7 @@ def test_titles(results):
     """Test extracting title."""
     expected_titles = [{
         'source': 'arXiv',
-        'title': (
-            "Irreversible degradation of quantum coherence under relativistic "
-            "motion"
-        ),
+        'title': '$L^2$ vanishing theorem on some Kähler manifolds',
     }]
     for record in results:
         assert 'titles' in record


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
LATEX characters in `title` and `abstract` are converted to `unicode` using `pylatexenc` as a postprocess.

## Related Issue
https://github.com/inspirehep/inspirehep/issues/1754