### PR TITLE
arXiv: only unescape safe LaTeX macros

### DIFF
--- a/tests/functional/arxiv/fixtures/arxiv_expected.json
+++ b/tests/functional/arxiv/fixtures/arxiv_expected.json
@@ -194,7 +194,7 @@
     "public_notes": [
       {
         "source": "arXiv",
-        "value": "78 pages, many figures, graphs and references. Version accepted for\n  publication in Quantum (completed missing part in the proof of reversibility\n  of time evolution, combined previous sections 6 and 7 to a rewritten section\n  6, added clarifications and minor corrections throughout -- overall improved\n  presentation, but results unaffected by revision)"
+        "value": "78 pages, many figures, graphs and references. Version accepted for\n publication in Quantum (completed missing part in the proof of reversibility\n of time evolution, combined previous sections 6 and 7 to a rewritten section\n 6, added clarifications and minor corrections throughout -- overall improved\n presentation, but results unaffected by revision)"
       }
     ],
     "number_of_pages": 78,
@@ -282,7 +282,7 @@
     "public_notes": [
       {
         "source": "arXiv",
-        "value": "Typos corrected, references added, version accepted for publication\n  in PRD"
+        "value": "Typos corrected, references added, version accepted for publication\n in PRD"
       }
     ],
     "authors": [
@@ -471,7 +471,7 @@
     "public_notes": [
       {
         "source": "arXiv",
-        "value": "43 pages, 13 tables, 17 figures; updated Figs. 11-17 and Tab. 12\n  including NLO corrections; version accepted for publication in EPJC"
+        "value": "43 pages, 13 tables, 17 figures; updated Figs. 11-17 and Tab. 12\n including NLO corrections; version accepted for publication in EPJC"
       }
     ],
     "number_of_pages": 43,

--- a/tests/functional/arxiv/fixtures/arxiv_expected_single.json
+++ b/tests/functional/arxiv/fixtures/arxiv_expected_single.json
@@ -7,7 +7,7 @@
     "public_notes": [
       {
         "source": "arXiv",
-        "value": "16 pages, LaTeX, no figures, revised and abridged, in this version\n  (v5) the typos were fixed (including some that have unfortunately crept into\n  the published version too), Letters in Mathematical Physics (2017)"
+        "value": "16 pages, LaTeX, no figures, revised and abridged, in this version\n (v5) the typos were fixed (including some that have unfortunately crept into\n the published version too), Letters in Mathematical Physics (2017)"
       }
     ],
     "citeable": true,

--- a/tests/unit/responses/arxiv/sample_arxiv_record0.xml
+++ b/tests/unit/responses/arxiv/sample_arxiv_record0.xml
@@ -29,7 +29,7 @@
 <forenames>Heng</forenames>
 </author>
 </authors>
-<title>$L^2$ vanishing theorem on some K\"{a}hler manifolds</title>
+<title>Irreversible degradation of quantum coherence under relativistic motion</title>
 <categories>quant-ph gr-qc hep-th</categories>
 <comments>6 pages, 4 figures, conference paper</comments>
 <report-no>YITP-2016-26</report-no>

--- a/tests/unit/responses/arxiv/sample_arxiv_record10_parsed.json
+++ b/tests/unit/responses/arxiv/sample_arxiv_record10_parsed.json
@@ -18,7 +18,7 @@
             "public_notes": [
                 {
                     "source": "arXiv",
-                    "value": "Phd thesis in Fundamental and Applied Physics presented at University\n  \"Federico II\" (Naples, Italy) on 29th April 2016"
+                    "value": "Phd thesis in Fundamental and Applied Physics presented at University\n \"Federico II\" (Naples, Italy) on 29th April 2016"
                 }
             ],
             "authors": [

--- a/tests/unit/test_arxiv_single.py
+++ b/tests/unit/test_arxiv_single.py
@@ -80,7 +80,7 @@ def test_titles(results):
     """Test extracting title."""
     expected_titles = [{
         'source': 'arXiv',
-        'title': '$L^2$ vanishing theorem on some Kähler manifolds',
+        'title': 'Irreversible degradation of quantum coherence under relativistic motion',
     }]
     for record in results:
         assert 'titles' in record

--- a/tests/unit/test_parsers_arxiv.py
+++ b/tests/unit/test_parsers_arxiv.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of hepcrawl.
+# Copyright (C) 2017 CERN.
+#
+# hepcrawl is a free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see LICENSE file for
+# more details.
+
+from hepcrawl.parsers.arxiv import ArxivParser
+
+
+def test_latex_to_unicode_handles_arxiv_escape_sequences():
+    expected = u"Kähler"
+    result = ArxivParser.latex_to_unicode(u'K\\"{a}hler')
+
+    assert result == expected
+
+
+def test_latex_to_unicode_handles_non_arXiv_escape_sequences():
+    expected = u"\u03bd\u03bd\u0305process"
+    result = ArxivParser.latex_to_unicode(u"\\nu\\bar\\nu process")
+
+    assert result == expected
+
+
+def test_latex_to_unicode_preserves_math():
+    expected = u'$H_{\\text{Schr\\"{o}dinger}}$'
+    result = ArxivParser.latex_to_unicode(u'$H_{\\text{Schr\\"{o}dinger}}$')
+
+    assert result == expected
+
+
+def test_latex_to_unicode_preserves_braces_containing_more_than_one_char():
+    expected = u"On the origin of the Type~{\\sc ii} spicules - dynamic 3D MHD simulations"
+    result = ArxivParser.latex_to_unicode(u"On the origin of the Type~{\\sc ii} spicules - dynamic 3D MHD simulations")
+
+    assert result == expected
+
+
+def test_latex_to_unicode_preserves_comments():
+    expected = u"A 4% measurement of $H_0$ using the cumulative distribution of strong-lensing time delays in doubly-imaged quasars"
+    result = ArxivParser.latex_to_unicode(u"A 4% measurement of $H_0$ using the cumulative distribution of strong-lensing time delays in doubly-imaged quasars")
+
+    assert result == expected
+
+
+def test_latex_to_unicode_handles_parens_after_sqrt():
+    expected = u"at \u221a(s) =192-202 GeV"
+    result = ArxivParser.latex_to_unicode(u"at  \\sqrt(s) =192-202 GeV")
+
+    assert result == expected
+
+
+def test_latex_to_unicode_handles_sqrt_without_parens():
+    expected = u"\u221a(s)"
+    result = ArxivParser.latex_to_unicode(u"\sqrt s")
+
+    assert result == expected
+
+
+def test_latex_to_unicode_preserves_spacing_after_macros():
+    expected = u"and DØ Experiments"
+    result = ArxivParser.latex_to_unicode(u"and D\\O Experiments")
+
+    assert result == expected


### PR DESCRIPTION
* Instead of unescaping everything and potentially lose meaningful info,
  now only macros which can be translated losslessly are handled
  (`latex-base` and `advanced-symbols` groups of `pylatexenc`). Macros
  not in these groups are preserved, as are braces when needed. The only
  issue is potentially wrong handling of whitespace, but that can't
  easily be fixed: we respect the spacing used in the source, but that
  might introduce additional whitespace if a macro is used in a middle
  of a word. That should be rare though.
* ref: inspirehep/inspirehep#1754